### PR TITLE
Package result-riscv.1.2

### DIFF
--- a/packages/result-riscv/result-riscv.1.2/opam
+++ b/packages/result-riscv/result-riscv.1.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+description: "
+Compatibility Result modules
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library."
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "git+https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD3"
+flags: light-uninstall
+build: [["env" "OCAMLFIND_TOOLCHAIN=riscv" make]]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "result.install"]]
+remove: [["ocamlfind" "-toolchain" "riscv" "remove" "result"]]
+depends: ["ocaml" "OCaml-RiscV"]
+extra-files: ["Makefile" "md5=c724b976aedf4b1160fe1e218dd46daa"]
+url {
+  src: "https://github.com/janestreet/result/archive/1.2.tar.gz"
+  checksum: "md5=3d5b66c5526918f0f2ca9d6811ef09c8"
+}
+synopsis: ""


### PR DESCRIPTION
### `result-riscv.1.2`

Compatibility Result modules
Projects that want to use the new result type defined in OCaml >= 4.03
while staying compatible with older version of OCaml should use the
Result module defined in this library.



---
* Homepage: https://github.com/janestreet/result
* Source repo: git+https://github.com/janestreet/result.git
* Bug tracker: https://github.com/janestreet/result/issues

---
:camel: Pull-request generated by opam-publish v2.0.0