### PR TITLE
Package uchar-riscv.0.0.2

### DIFF
--- a/packages/uchar-riscv/uchar-riscv.0.0.2/opam
+++ b/packages/uchar-riscv/uchar-riscv.0.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+description: "Compatibility library for OCaml's Uchar module
+
+The `uchar` package provides a compatibility library for the
+[`Uchar`][1] module introduced in OCaml 4.03.
+
+The `uchar` package is distributed under the license of the OCaml
+compiler. See [LICENSE](LICENSE) for details.
+[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html"
+
+homepage: "http://ocaml.org"
+doc: "https://ocaml.github.io/uchar/"
+dev-repo: "git+https://github.com/ocaml/uchar.git"
+bug-reports: "https://github.com/ocaml/uchar/issues"
+tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
+license: "typeof OCaml system"
+depends: [ 
+	"ocamlbuild" {build} 
+	"OCaml-RiscV"
+	"ocaml" {= "4.07.0"} 
+]
+build:
+[
+  [ "ocaml" "pkg/git.ml" ]
+  [ "env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "pkg/build.ml"  "native=false"
+                            "native-dynlink=false"]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "uchar.install"]]
+url {
+	src: "https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz"
+	checksum: "c9ba2c738d264c420c642f7bb1cf4a36"
+}
+synopsis: ""


### PR DESCRIPTION
### `uchar-riscv.0.0.2`

Compatibility library for OCaml's Uchar module

The `uchar` package provides a compatibility library for the
[`Uchar`][1] module introduced in OCaml 4.03.

The `uchar` package is distributed under the license of the OCaml
compiler. See [LICENSE](LICENSE) for details.
[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html



---
* Homepage: http://ocaml.org
* Source repo: git+https://github.com/ocaml/uchar.git
* Bug tracker: https://github.com/ocaml/uchar/issues

---
:camel: Pull-request generated by opam-publish v2.0.0