### PR TITLE
Package duration-riscv.0.1.1

### DIFF
--- a/packages/duration-riscv/duration-riscv.0.1.1/opam
+++ b/packages/duration-riscv/duration-riscv.0.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+description: "A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+dev-repo: "git+https://github.com/hannesm/duration.git"
+bug-reports: "https://github.com/hannesm/duration/issues"
+license: "ISC"
+
+depends: [
+  "ocaml-riscv"
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+]
+build: [
+  ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--toolchain" "riscv"]
+]
+synopsis: "Conversions to various time units"
+
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "duration.install"]]
+url {
+	src:"https://github.com/hannesm/duration/releases/download/0.1.1/duration-0.1.1.tbz"
+	checksum: "160e36e2ba16a01492c8c2b6d8c496ac"
+}


### PR DESCRIPTION
### `duration-riscv.0.1.1`
Conversions to various time units
A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
has a range of up to 584 years.  Functions provided check the input and raise
on negative or out of bound input



---
* Homepage: https://github.com/hannesm/duration
* Source repo: git+https://github.com/hannesm/duration.git
* Bug tracker: https://github.com/hannesm/duration/issues

---
:camel: Pull-request generated by opam-publish v2.0.0