### PR TITLE
Package duration-riscv.0.1.1

### DIFF
--- a/packages/duration-riscv/duration-riscv.0.1.1/opam
+++ b/packages/duration-riscv/duration-riscv.0.1.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/hannesm/duration/issues"
 license: "ISC"
 
 depends: [
-  "ocaml-riscv"
+  "OCaml-RiscV"
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
### `duration-riscv.0.1.1`
Conversions to various time units
A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
has a range of up to 584 years.  Functions provided check the input and raise
on negative or out of bound input



---
* Homepage: https://github.com/hannesm/duration
* Source repo: git+https://github.com/hannesm/duration.git
* Bug tracker: https://github.com/hannesm/duration/issues

---
:camel: Pull-request generated by opam-publish v2.0.0