### PR TITLE
Package ocaml-compiler-libs-riscv.v0.10.0

### DIFF
--- a/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.v0.10.0/opam
+++ b/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.v0.10.0/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 synopsis: "OCaml compiler libraries repackaged"
 
-install: [["opam-installer" "--prefix=%{prefix}%/esp32-sysroot" "ocaml-compiler-libs.install"]]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv32-sysroot" "ocaml-compiler-libs.install"]]
 url {
 	src:"https://ocaml.janestreet.com/ocaml-core/v0.10/files/ocaml-compiler-libs-v0.10.0.tar.gz"
 	checksum: "e94f23c3478cb42dc3472617ea86c800"	


### PR DESCRIPTION
### `ocaml-compiler-libs-riscv.v0.10.0`
OCaml compiler libraries repackaged



---
* Homepage: https://github.com/janestreet/ocaml-compiler-libs
* Source repo: git+https://github.com/janestreet/ocaml-compiler-libs.git
* Bug tracker: https://github.com/janestreet/ocaml-compiler-libs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0