### PR TITLE
Package base-nat-riscv.0.10.0

### DIFF
--- a/packages/base-nat-riscv/base-nat-riscv.0.10.0/opam
+++ b/packages/base-nat-riscv/base-nat-riscv.0.10.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+description: "Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" "base" "-j" jobs]
+]
+depends: [
+  "OCaml-RiscV" {>= "4.04.1"}
+  "jbuilder" {build & >= "1.0+beta12"}
+  "sexplib" {>= "v0.10" & < "v0.11"}
+]
+depopts: [
+  "base-native-int63"
+]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "base.install"]]
+url{
+	src: "https://ocaml.janestreet.com/ocaml-core/v0.10/files/base-v0.10.0.tar.gz"
+	checksum: "60a9db475c689720cc7fc4304e00b00e"
+}
+synopsis: ""


### PR DESCRIPTION
### `base-nat-riscv.0.10.0`

Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0