### PR TITLE
Package num-riscv.1.1

### DIFF
--- a/packages/num-riscv/num-riscv.1.1/opam
+++ b/packages/num-riscv/num-riscv.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+description: "The legacy Num library for arbitrary-precision integer and rational arithmetic"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: [
+  "Valérie Ménissier-Morain"
+  "Pierre Weis"
+  "Xavier Leroy"
+]
+license: "LGPL 2.1 with OCaml linking exception"
+
+homepage: "https://github.com/ocaml/num/"
+bug-reports: "https://github.com/ocaml/num/issues"
+dev-repo: "git+https://github.com/ocaml/num.git"
+
+build: [
+  [make]
+]
+install: ["env" "OCAMLFIND_TOOLCHAIN=riscv" make "install"]
+
+depends: [
+  "ocamlfind" {build & >= "1.7.3"}
+  "OCaml-RiscV"
+  "ocaml"  {= "4.07.0"} 
+]
+extra-files: [["findlib-install.patch.in" "md5=4239ae31352247893bbe9ec437e9657a"]]
+conflicts: [ "base-num" ]
+substs: [ "findlib-install.patch" ]
+patches: [ "findlib-install.patch" ]
+url {
+	archive: "https://github.com/ocaml/num/archive/v1.1.tar.gz"
+	checksum: "710cbe18b144955687a03ebab439ff2b"
+}
+synopsis: ""


### PR DESCRIPTION
### `num-riscv.1.1`

The legacy Num library for arbitrary-precision integer and rational arithmetic



---
* Homepage: https://github.com/ocaml/num/
* Source repo: git+https://github.com/ocaml/num.git
* Bug tracker: https://github.com/ocaml/num/issues

---
:camel: Pull-request generated by opam-publish v2.0.0