### PR TITLE
Package sexplib-riscv.0.12.0

### DIFF
--- a/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
+++ b/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
@@ -21,7 +21,11 @@ depends: [
   "ocaml" {= "4.07.0"} 
 ]
 url {
-	src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib-v0.12.0.tar.gz"
-	checksum: "b8f5db21a2b19aadc753c6e626019068"
+  src:
+    "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib-v0.12.0.tar.gz"
+  checksum: [
+    "md5=a7f9f8a414aed6cc56901199cda020f6"
+    "sha512=bd050e59f5269f15b3362891f98417c78bbe6e18c630488ac3df769dd70180beb4e1bbf55e32327fd2dec9a6041969bcaa4f9d16b9295e33cc82af1515404701"
+  ]
 }
 synopsis: ""


### PR DESCRIPTION
### `sexplib-riscv.0.12.0`

Library for serializing OCaml values to and from S-expressions

Part of Jane Street's Core library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.



---
* Homepage: https://github.com/janestreet/sexplib
* Source repo: git+https://github.com/janestreet/sexplib.git
* Bug tracker: https://github.com/janestreet/sexplib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0