### PR TITLE
Package sexplib-riscv.0.12.0

### DIFF
--- a/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
+++ b/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
@@ -17,6 +17,8 @@ build: [
 depends: [
   "dune"     {build & >= "1.5.1"}
   "num-riscv"
+  "parsexp"  {>= "v0.12" & < "v0.13"}
+  "sexplib0" {>= "v0.12" & < "v0.13"}
   "OCaml-RiscV"
   "ocaml" {= "4.07.0"} 
 ]


### PR DESCRIPTION
### `sexplib-riscv.0.12.0`

Library for serializing OCaml values to and from S-expressions

Part of Jane Street's Core library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.



---
* Homepage: https://github.com/janestreet/sexplib
* Source repo: git+https://github.com/janestreet/sexplib.git
* Bug tracker: https://github.com/janestreet/sexplib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0