### PR TITLE
Package parsexp-riscv.v0.12.0

### DIFF
--- a/packages/parsexp-riscv/parsexp-riscv.v0.12.0/opam
+++ b/packages/parsexp-riscv/parsexp-riscv.v0.12.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/parsexp"
+bug-reports: "https://github.com/janestreet/parsexp/issues"
+dev-repo: "git+https://github.com/janestreet/parsexp.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/parsexp/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-x" "riscv" "-p" "parsexp" "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "OCaml-RiscV"
+  "base"
+  "sexplib0"
+  "dune"     {build & >= "1.5.1"}
+]
+synopsis: "S-expression parsing library"
+description: "
+This library provides generic parsers for parsing S-expressions from
+strings or other medium.
+
+The library is focused on performances but still provide full generic
+parsers that can be used with strings, bigstrings, lexing buffers,
+character streams or any other sources effortlessly.
+
+It provides three different class of parsers:
+- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
+- the parsers with positions, building compact position sequences so
+  that one can recover original positions in order to report properly
+  located errors at little cost
+- the Concrete Syntax Tree parsers, produce values of type
+  [Parsexp.Cst.t] which record the concrete layout of the s-expression
+  syntax, including comments
+
+This library is portable and doesn't provide IO functions. To read
+s-expressions from files or other external sources, you should use
+parsexp_io.
+"
+url {
+  src:
+    "https://ocaml.janestreet.com/ocaml-core/v0.12/files/parsexp-v0.12.0.tar.gz"
+  checksum: [
+    "md5=741b2c6f59b9618e3affabaa34d468a2"
+    "sha512=849968ac69709b293208fabde5cc22972a3def3ed35517e571c5127b417c7129a0d9eafc94fd580508203b611a9614b2612670dbdf69887b0e71f7cc5278bf12"
+  ]
+}


### PR DESCRIPTION
### `parsexp-riscv.v0.12.0`
S-expression parsing library
This library provides generic parsers for parsing S-expressions from
strings or other medium.

The library is focused on performances but still provide full generic
parsers that can be used with strings, bigstrings, lexing buffers,
character streams or any other sources effortlessly.

It provides three different class of parsers:
- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
- the parsers with positions, building compact position sequences so
  that one can recover original positions in order to report properly
  located errors at little cost
- the Concrete Syntax Tree parsers, produce values of type
  [Parsexp.Cst.t] which record the concrete layout of the s-expression
  syntax, including comments

This library is portable and doesn't provide IO functions. To read
s-expressions from files or other external sources, you should use
parsexp_io.



---
* Homepage: https://github.com/janestreet/parsexp
* Source repo: git+https://github.com/janestreet/parsexp.git
* Bug tracker: https://github.com/janestreet/parsexp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0