### PR TITLE
Package OCaml-RiscV.4.07.0

### DIFF
--- a/packages/OCaml-RiscV/OCaml-RiscV.4.07.0/opam
+++ b/packages/OCaml-RiscV/OCaml-RiscV.4.07.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Ocaml to RiscV Cross Compiler."
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: "KC Sivaramakrishnan <kc@kcsrk.info>"
+license: "LGPL v2.1"
+homepage: "https://github.com/kayceesrk/riscv-ocaml/tree/4.07+cross"
+substs: [ "riscv.conf" ]
+depends: [ 
+	"ocaml" {= "4.07.0"} 
+	"ocamlfind"
+	#should add gcc-toolchain-riscv 
+]
+build: [
+	["sh" "./configure" "--target" "riscv64-unknown-linux-gnu" "-prefix" "%{prefix}%/riscv-sysroot" "-no-ocamldoc" "-no-debugger" "-target-bindir" "%{prefix}%/riscv-sysroot/bin"]
+	["sh" "./build.sh"]
+]
+install: [
+	["cp" "%{prefix}%/bin/ocamlrun" "byterun"]
+	[make "install"]
+	["sh" "./install.sh"]
+]
+remove: [
+    [ "rm" "-rf" "%{prefix}%/esp32-sysroot" ]
+]
+url {
+  src: "https://github.com/SaiVK/OCaml-RiscV/archive/v4.07.0.tar.gz"
+  checksum: [
+    "md5=a6f4e82b271d6e5f7451c27ce8e3fc05"
+    "sha512=135026930de9a049ff1610711722bcb619ebc6a757e7f55373030a846749ef5e86d1e5764535c859fb2ea8c77ab7e310a27cc0bfc49d38f106e410225ae570d3"
+  ]
+}


### PR DESCRIPTION
### `OCaml-RiscV.4.07.0`
Ocaml to RiscV Cross Compiler.



---
* Homepage: https://github.com/kayceesrk/riscv-ocaml/tree/4.07+cross

---
:camel: Pull-request generated by opam-publish v2.0.0