### PR TITLE
Package result-riscv.1.4

### DIFF
--- a/packages/result-riscv/result-riscv.1.4/opam
+++ b/packages/result-riscv/result-riscv.1.4/opam
@@ -18,7 +18,7 @@ remove: [["ocamlfind" "-toolchain" "riscv" "remove" "result"]]
 
 depends: [
 	"ocaml" {= "4.07.0"} 
-	"OCaml-RiscV"
+	"ocaml-riscv"
 	"dune" {build & >= "1.0"}
 ]
 


### PR DESCRIPTION
### `result-riscv.1.4`

Projects that want to use the new result type defined in OCaml >= 4.03
while staying compatible with older version of OCaml should use the
Result module defined in this library.



---
* Homepage: https://github.com/janestreet/result
* Source repo: git+https://github.com/janestreet/result.git
* Bug tracker: https://github.com/janestreet/result/issues

---
:camel: Pull-request generated by opam-publish v2.0.0