### PR TITLE
Package result-riscv.1.4

### DIFF
--- a/packages/result-riscv/result-riscv.1.4/opam
+++ b/packages/result-riscv/result-riscv.1.4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+description: """
+Projects that want to use the new result type defined in OCaml >= 4.03
+while staying compatible with older version of OCaml should use the
+Result module defined in this library."""
+
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/result"
+dev-repo: "git+https://github.com/janestreet/result.git"
+bug-reports: "https://github.com/janestreet/result/issues"
+license: "BSD3"
+
+
+build: [["dune" "build" "-x" "riscv" "-p" "result" "-j" jobs]] 
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "result"]]
+remove: [["ocamlfind" "-toolchain" "riscv" "remove" "result"]]
+
+depends: [
+	"ocaml" {= "4.07.0"} 
+	"ocaml-riscv"
+	"dune" {build & >= "1.0"}
+]
+
+url {
+  src: "https://github.com/janestreet/result/archive/1.4.tar.gz"
+  checksum: "md5=d3162dbc501a2af65c8c71e0866541da"
+}
+synopsis: ""


### PR DESCRIPTION
### `result-riscv.1.4`

Projects that want to use the new result type defined in OCaml >= 4.03
while staying compatible with older version of OCaml should use the
Result module defined in this library.



---
* Homepage: https://github.com/janestreet/result
* Source repo: git+https://github.com/janestreet/result.git
* Bug tracker: https://github.com/janestreet/result/issues

---
:camel: Pull-request generated by opam-publish v2.0.0