### PR TITLE
Package ocaml-compiler-libs-riscv.0.12.0

### DIFF
--- a/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.0.12.0/opam
+++ b/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.0.12.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ocaml-compiler-libs"
+bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
+license: "Apache-2.0"
+
+build: [
+  ["dune" "build" "-p" "ocaml-compiler-libs" "-j" jobs]
+]
+depends: [
+	"ocaml" {= "4.07.0"}
+    "ocaml-riscv"
+    "dune" {build & >= "1.0"}
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ocaml-compiler-libs"]]
+
+synopsis: "OCaml compiler libraries repackaged"
+description: """
+This packages exposes the OCaml compiler libraries repackages under
+the toplevel names Ocaml_common, Ocaml_bytecomp, ..."""
+
+url {
+  src: "https://github.com/janestreet/ocaml-compiler-libs/archive/v0.12.0.tar.gz"
+  checksum: "md5=3351925ed99be59829641d2044fc80c0"
+}


### PR DESCRIPTION
### `ocaml-compiler-libs-riscv.0.12.0`
OCaml compiler libraries repackaged
This packages exposes the OCaml compiler libraries repackages under
the toplevel names Ocaml_common, Ocaml_bytecomp, ...



---
* Homepage: https://github.com/janestreet/ocaml-compiler-libs
* Source repo: git+https://github.com/janestreet/ocaml-compiler-libs.git
* Bug tracker: https://github.com/janestreet/ocaml-compiler-libs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0