### PR TITLE
Package duration-riscv.0.1.2

### DIFF
--- a/packages/duration-riscv/duration-riscv.0.1.2/opam
+++ b/packages/duration-riscv/duration-riscv.0.1.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+dev-repo: "git+https://github.com/hannesm/duration.git"
+bug-reports: "https://github.com/hannesm/duration/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {= "4.07.0"}
+  "ocaml-riscv"
+  "dune" {build}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "duration" "-j" jobs]
+  ["dune" "runtest" "-p" "duration" "-j" jobs] {with-test}
+]
+
+synopsis: "Conversions to various time units"
+description: """
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.
+"""
+
+url {
+  src:
+    "https://github.com/hannesm/duration/releases/download/0.1.2/duration-0.1.2.tbz"
+  checksum: "md5=2fca16d20fe9413948a309084ac66261"
+}


### PR DESCRIPTION
### `duration-riscv.0.1.2`
Conversions to various time units
A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
has a range of up to 584 years.  Functions provided check the input and raise
on negative or out of bound input.



---
* Homepage: https://github.com/hannesm/duration
* Source repo: git+https://github.com/hannesm/duration.git
* Bug tracker: https://github.com/hannesm/duration/issues

---
:camel: Pull-request generated by opam-publish v2.0.0