### PR TITLE
Package sexplib0-riscv.0.12.0

### DIFF
--- a/packages/sexplib0-riscv/sexplib0-riscv.0.12.0/opam
+++ b/packages/sexplib0-riscv/sexplib0-riscv.0.12.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/sexplib0"
+bug-reports: "https://github.com/janestreet/sexplib0/issues"
+dev-repo: "git+https://github.com/janestreet/sexplib0.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/sexplib0/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-x" "riscv" "-p" "sexplib0" "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "ocaml-riscv"
+  "dune"  {build & >= "1.5.1"}
+]
+synopsis: "Library containing the definition of S-expressions and some base converters"
+description: "
+Part of Jane Street's Core library
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/sexplib0-v0.12.0.tar.gz"
+  checksum: "md5=2486a25d3a94da9a94acc018b5f09061"
+}


### PR DESCRIPTION
### `sexplib0-riscv.0.12.0`
Library containing the definition of S-expressions and some base converters
Part of Jane Street's Core library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.



---
* Homepage: https://github.com/janestreet/sexplib0
* Source repo: git+https://github.com/janestreet/sexplib0.git
* Bug tracker: https://github.com/janestreet/sexplib0/issues

---
:camel: Pull-request generated by opam-publish v2.0.0