### PR TITLE
Package ocaml-riscv.4.07.0

### DIFF
--- a/packages/ocaml-riscv/ocaml-riscv.4.07.0/opam
+++ b/packages/ocaml-riscv/ocaml-riscv.4.07.0/opam
@@ -16,7 +16,7 @@ build: [
 ]
 install: [
 	["cp" "%{prefix}%/bin/ocamlrun" "byterun"]
-	#["cp" "%{prefix}%/lib/ocaml" "%{prefix}%/riscv-sysroot/lib/ocaml"]
+	[make "opt.opt"]
 	[make "install"]
 	["sh" "./install.sh"]
 ]
@@ -26,7 +26,7 @@ remove: [
 url {
   src: "https://github.com/SaiVK/OCaml-RiscV/archive/v4.07.0.tar.gz"
   checksum: [
-    "md5=3a1fb0b50a0f6c8d24bfad606ee4fe6e"
-    "sha512=1ac1ff879df6504264a8b9af4000f98d786239bd6b40703111d0cdcc535f92e360460312980a9768ff1adee5b2bd5e9b11654b99e43a5539eb606bbb01fd3fa7"
+    "md5=176d185acfc0ea07f4e1c927fb48738d"
+    "sha512=4e624e9d5ffeae2b4c8280a42a44eb24fbbd47c349a01a89440b555419394885be57883cfd0a8185c8e078d72c9ccacbd70aaf6e6b6b37d4070197d89c798b4d"
   ]
 }


### PR DESCRIPTION
### `ocaml-riscv.4.07.0`
Ocaml to RiscV Cross Compiler.



---
* Homepage: https://github.com/kayceesrk/riscv-ocaml/tree/4.07+cross

---
:camel: Pull-request generated by opam-publish v2.0.0