### PR TITLE
Package base-nat-riscv.0.12.2

### DIFF
--- a/packages/base-nat-riscv/base-nat-riscv.0.12.2/opam
+++ b/packages/base-nat-riscv/base-nat-riscv.0.12.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+description: "Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+license: "Apache-2.0"
+
+build: [
+  ["dune" "build" "-p" "base" "-j" jobs]
+]
+depends: [
+  "ocaml"             {= "4.07.0"}
+  "ocaml-riscv"
+  "sexplib0"          {>= "0.12" & < "0.13"}
+  "dune"              {build & >= "1.5.1"}
+]
+depopts: [
+  "base-native-int63"
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "base"]]
+
+url {
+  src: "https://github.com/janestreet/base/archive/v0.12.2.tar.gz"
+  checksum: "md5=7150e848a730369a2549d01645fb6c72"
+}
+synopsis: ""


### PR DESCRIPTION
### `base-nat-riscv.0.12.2`

Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0