### PR TITLE
Package base-nat-riscv.0.12.2

### DIFF
--- a/packages/base-nat-riscv/base-nat-riscv.0.12.2/opam
+++ b/packages/base-nat-riscv/base-nat-riscv.0.12.2/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml"             {= "4.07.0"}
   "ocaml-riscv"
-  "sexplib0"          {>= "0.12" & < "0.13"}
+  "sexplib0"          
   "dune"              {build & >= "1.5.1"}
 ]
 depopts: [


### PR DESCRIPTION
### `base-nat-riscv.0.12.2`

Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.0.0