### PR TITLE
Package parsexp-riscv.v0.12.0

### DIFF
--- a/packages/parsexp-riscv/parsexp-riscv.v0.12.0/opam
+++ b/packages/parsexp-riscv/parsexp-riscv.v0.12.0/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "OCaml-RiscV"
+  "ocaml-riscv"
   "base"
   "sexplib0-riscv"
   "dune"     {build & >= "1.5.1"}


### PR DESCRIPTION
### `parsexp-riscv.v0.12.0`
S-expression parsing library
This library provides generic parsers for parsing S-expressions from
strings or other medium.

The library is focused on performances but still provide full generic
parsers that can be used with strings, bigstrings, lexing buffers,
character streams or any other sources effortlessly.

It provides three different class of parsers:
- the normal parsers, producing [Sexp.t] or [Sexp.t list] values
- the parsers with positions, building compact position sequences so
  that one can recover original positions in order to report properly
  located errors at little cost
- the Concrete Syntax Tree parsers, produce values of type
  [Parsexp.Cst.t] which record the concrete layout of the s-expression
  syntax, including comments

This library is portable and doesn't provide IO functions. To read
s-expressions from files or other external sources, you should use
parsexp_io.



---
* Homepage: https://github.com/janestreet/parsexp
* Source repo: git+https://github.com/janestreet/parsexp.git
* Bug tracker: https://github.com/janestreet/parsexp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0