### PR TITLE
Package sexplib-riscv.0.12.0

### DIFF
--- a/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
+++ b/packages/sexplib-riscv/sexplib-riscv.0.12.0/opam
@@ -17,8 +17,8 @@ build: [
 depends: [
   "dune"     {build & >= "1.5.1"}
   "num-riscv"
-  "parsexp-riscv"  {>= "0.12" & < "0.13"}
-  "sexplib0-riscv" {>= "0.12" & < "0.13"}
+  "parsexp-riscv"  
+  "sexplib0-riscv" 
   "ocaml-riscv"
   "ocaml" {= "4.07.0"} 
 ]


### PR DESCRIPTION
### `sexplib-riscv.0.12.0`

Library for serializing OCaml values to and from S-expressions

Part of Jane Street's Core library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.



---
* Homepage: https://github.com/janestreet/sexplib
* Bug tracker: https://github.com/janestreet/sexplib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0