### PR TITLE
Package stdio-nat-riscv.0.12.0

### DIFF
--- a/packages/stdio-nat-riscv/stdio-nat-riscv.0.12.0/opam
+++ b/packages/stdio-nat-riscv/stdio-nat-riscv.0.12.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/stdio"
+bug-reports: "https://github.com/janestreet/stdio/issues"
+dev-repo: "git+https://github.com/janestreet/stdio.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/stdio/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "stdio" "-j" jobs]
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "stdio"]]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "ocaml-riscv"
+  "base"  {>= "v0.12" & < "v0.13"}
+  "dune"  {build & >= "1.5.1"}
+]
+synopsis: "Standard IO library for OCaml"
+description: "
+Stdio implements simple input/output functionalities for OCaml.
+
+It re-exports the input/output functions of the OCaml standard
+libraries using a more consistent API.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/stdio-v0.12.0.tar.gz"
+  checksum: "md5=b261ff2d5667fde960c95e50cff668da"
+}


### PR DESCRIPTION
### `stdio-nat-riscv.0.12.0`
Standard IO library for OCaml
Stdio implements simple input/output functionalities for OCaml.

It re-exports the input/output functions of the OCaml standard
libraries using a more consistent API.



---
* Homepage: https://github.com/janestreet/stdio
* Source repo: git+https://github.com/janestreet/stdio.git
* Bug tracker: https://github.com/janestreet/stdio/issues

---
:camel: Pull-request generated by opam-publish v2.0.0