### PR TITLE
Package stdlib-shims-riscv.0.1.0

### DIFF
--- a/packages/stdlib-shims-riscv/stdlib-shims-riscv.0.1.0/opam
+++ b/packages/stdlib-shims-riscv/stdlib-shims-riscv.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: "The stdlib-shims programmers"
+homepage: "https://github.com/ocaml/stdlib-shims"
+doc: "https://ocaml.github.io/stdlib-shims/"
+dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
+bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
+tags: ["stdlib" "compatibility" "org:ocaml"]
+license: ["typeof OCaml system"]
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.02.3"}
+  "ocaml-riscv"
+]
+build: [ "dune" "build" "-x" "riscv" "-p" "stdlib-shims" "-j" jobs ]
+synopsis: "Backport some of the new stdlib features to older compiler"
+description: """
+Backport some of the new stdlib features to older compiler,
+such as the Stdlib module.
+
+This allows projects that require compatibility with older compiler to
+use these new features in their code.
+"""
+url {
+  src:
+    "https://github.com/ocaml/stdlib-shims/releases/download/0.1.0/stdlib-shims-0.1.0.tbz"
+  checksum: "md5=12b5704eed70c6bff5ac39a16db1425d"
+}


### PR DESCRIPTION
### `stdlib-shims-riscv.0.1.0`
Backport some of the new stdlib features to older compiler
Backport some of the new stdlib features to older compiler,
such as the Stdlib module.

This allows projects that require compatibility with older compiler to
use these new features in their code.



---
* Homepage: https://github.com/ocaml/stdlib-shims
* Source repo: git+https://github.com/ocaml/stdlib-shims.git
* Bug tracker: https://github.com/ocaml/stdlib-shims/issues

---
:camel: Pull-request generated by opam-publish v2.0.0