### PR TITLE
Package cmdliner-riscv.1.0.2

### DIFF
--- a/packages/cmdliner-riscv/cmdliner-riscv.1.0.2/opam
+++ b/packages/cmdliner-riscv/cmdliner-riscv.1.0.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+homepage: "http://erratique.ch/software/cmdliner"
+doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
+dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+tags: [ "cli" "system" "declarative" "org:erratique" ]
+license: "ISC"
+depends:[
+  "ocaml" {= "4.07.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "result-riscv"
+  "ocaml-riscv"
+]
+build: [[
+  "ocaml" "pkg/pkg.ml" "build"
+          "--pinned" "%{pinned}%"
+          "--toolchain" "riscv"
+]]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "cmdliner.install"]]
+
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html"""
+url {
+  src: "http://erratique.ch/software/cmdliner/releases/cmdliner-1.0.2.tbz"
+  checksum: "md5=ab2f0130e88e8dcd723ac6154c98a881"
+}


### PR DESCRIPTION
### `cmdliner-riscv.1.0.2`
Declarative definition of command line interfaces for OCaml
Cmdliner allows the declarative definition of command line interfaces
for OCaml.

It provides a simple and compositional mechanism to convert command
line arguments to OCaml values and pass them to your functions. The
module automatically handles syntax errors, help messages and UNIX man
page generation. It supports programs with single or multiple commands
and respects most of the [POSIX][1] and [GNU][2] conventions.

Cmdliner has no dependencies and is distributed under the ISC license.

[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html



---
* Homepage: http://erratique.ch/software/cmdliner
* Source repo: git+http://erratique.ch/repos/cmdliner.git
* Bug tracker: https://github.com/dbuenzli/cmdliner/issues

---
:camel: Pull-request generated by opam-publish v2.0.0