### PR TITLE
Package topkg-riscv.1.0.0

### DIFF
--- a/packages/topkg-riscv/topkg-riscv.1.0.0/opam
+++ b/packages/topkg-riscv/topkg-riscv.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "result" ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
-          "--pkg-name" name
+          "--pkg-name" "topkg"
           "--dev-pkg" "%{pinned}%" ]]
 
 install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "topkg.install"]]


### PR DESCRIPTION
### `topkg-riscv.1.0.0`
The transitory OCaml software packager
Topkg is a packager for distributing OCaml software. It provides an
API to describe the files a package installs in a given build
configuration and to specify information about the package's
distribution, creation and publication procedures.

The optional topkg-care package provides the `topkg` command line tool
which helps with various aspects of a package's life cycle: creating
and linting a distribution, releasing it on the WWW, publish its
documentation, add it to the OCaml opam repository, etc.

Topkg is distributed under the ISC license and has **no**
dependencies. This is what your packages will need as a *build*
dependency.

Topkg-care is distributed under the ISC license it depends on
[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
[webbrowser][webbrowser] and `opam-format`.

[fmt]: http://erratique.ch/software/fmt
[logs]: http://erratique.ch/software/logs
[bos]: http://erratique.ch/software/bos
[cmdliner]: http://erratique.ch/software/cmdliner
[webbrowser]: http://erratique.ch/software/webbrowser



---
* Homepage: http://erratique.ch/software/topkg
* Source repo: git+http://erratique.ch/repos/topkg.git
* Bug tracker: https://github.com/dbuenzli/topkg/issues

---
:camel: Pull-request generated by opam-publish v2.0.0