### PR TITLE
Package re-riscv.1.9.0

### DIFF
--- a/packages/re-riscv/re-riscv.1.9.0/opam
+++ b/packages/re-riscv/re-riscv.1.9.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.0 with OCaml linking exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "re" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build}
+  "ounit" {with-test}
+  "ocaml-riscv"
+]
+
+synopsis: "RE is a regular expression library for OCaml"
+description: """
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)
+"""
+url {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.9.0/re-1.9.0.tbz"
+  checksum: "md5=bddaed4f386a22cace7850c9c7dac296"
+}


### PR DESCRIPTION
### `re-riscv.1.9.0`
RE is a regular expression library for OCaml
Pure OCaml regular expressions with:
* Perl-style regular expressions (module Re.Perl)
* Posix extended regular expressions (module Re.Posix)
* Emacs-style regular expressions (module Re.Emacs)
* Shell-style file globbing (module Re.Glob)
* Compatibility layer for OCaml's built-in Str module (module Re.Str)



---
* Homepage: https://github.com/ocaml/ocaml-re
* Source repo: git+https://github.com/ocaml/ocaml-re.git
* Bug tracker: https://github.com/ocaml/ocaml-re/issues

---
:camel: Pull-request generated by opam-publish v2.0.0