### PR TITLE
Package ocplib-endian-riscv.1.0

### DIFF
--- a/packages/ocplib-endian-riscv/ocplib-endian-riscv.1.0/opam
+++ b/packages/ocplib-endian-riscv/ocplib-endian-riscv.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: "Pierre Chambart"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+homepage: "https://github.com/OCamlPro/ocplib-endian"
+build: [
+  ["env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "setup.ml" "-configure" "--override" "native_dynlink" "false" "--prefix" "%{prefix}%/riscv-sysroot"]
+  ["env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+#remove: ["ocamlfind" "remove" "ocplib-endian"]
+depends: [
+  "ocaml" {= "4.07.0"}
+  "base-bytes"
+  "ocamlfind"
+  "cppo-riscv" 
+  "ocaml-riscv"
+  "ocamlbuild" {build}
+]
+dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
+bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
+synopsis:
+  "Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01."
+description: """
+The library implements three modules:
+* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.cppo.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.cppo.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.cppo.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;"""
+#flags: light-uninstall
+url {
+  src: "https://github.com/OCamlPro/ocplib-endian/archive/1.0.tar.gz"
+  checksum: "md5=74b45ba33e189283170a748c2a3ed477"
+}


### PR DESCRIPTION
### `ocplib-endian-riscv.1.0`
Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01.
The library implements three modules:
* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.cppo.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.cppo.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.cppo.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;



---
* Homepage: https://github.com/OCamlPro/ocplib-endian
* Source repo: git+https://github.com/OCamlPro/ocplib-endian.git
* Bug tracker: https://github.com/OCamlPro/ocplib-endian/issues

---
:camel: Pull-request generated by opam-publish v2.0.0