### PR TITLE
Package ocplib-endian-riscv.1.0

### DIFF
--- a/packages/ocplib-endian-riscv/ocplib-endian-riscv.1.0/opam
+++ b/packages/ocplib-endian-riscv/ocplib-endian-riscv.1.0/opam
@@ -7,7 +7,7 @@ build: [
   ["env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "setup.ml" "-build"]
 ]
 install: [
-  ["ocaml" "setup.ml" "-install"]
+  ["env" "OCAMLFIND_TOOLCHAIN=esp32" "ocaml" "setup.ml" "-install"]
 ]
 #remove: ["ocamlfind" "remove" "ocplib-endian"]
 depends: [


### PR DESCRIPTION
### `ocplib-endian-riscv.1.0`
Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01.
The library implements three modules:
* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.cppo.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.cppo.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.cppo.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;



---
* Homepage: https://github.com/OCamlPro/ocplib-endian
* Source repo: git+https://github.com/OCamlPro/ocplib-endian.git
* Bug tracker: https://github.com/OCamlPro/ocplib-endian/issues

---
:camel: Pull-request generated by opam-publish v2.0.0