### PR TITLE
Package mmap-riscv.1.1.0

### DIFF
--- a/packages/mmap-riscv/mmap-riscv.1.1.0/opam
+++ b/packages/mmap-riscv/mmap-riscv.1.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jérémie Dimino <jeremie@dimino.org>" "Anton Bachin" ]
+homepage: "https://github.com/mirage/mmap"
+bug-reports: "https://github.com/mirage/mmap/issues"
+doc: "https://mirage.github.io/mmap/"
+dev-repo: "git+https://github.com/mirage/mmap.git"
+license: "LGPL 2.1 with linking exception"
+build: [
+  ["dune" "build" "-x" "riscv" "-p" "mmap" "-j" jobs]
+]
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.6"}
+  "ocaml-riscv"
+]
+synopsis: "File mapping functionality"
+description: """
+This project provides a Mmap.map_file functions for mapping files in memory.
+"""
+url {
+  src:
+    "https://github.com/mirage/mmap/releases/download/v1.1.0/mmap-v1.1.0.tbz"
+  checksum: "md5=8c5d5fbc537296dc525867535fb878ba"
+}


### PR DESCRIPTION
### `mmap-riscv.1.1.0`
File mapping functionality
This project provides a Mmap.map_file functions for mapping files in memory.



---
* Homepage: https://github.com/mirage/mmap
* Source repo: git+https://github.com/mirage/mmap.git
* Bug tracker: https://github.com/mirage/mmap/issues

---
:camel: Pull-request generated by opam-publish v2.0.0