### PR TITLE
Package io-page-riscv.2.3.0

### DIFF
--- a/packages/io-page-riscv/io-page-riscv.2.3.0/opam
+++ b/packages/io-page-riscv/io-page-riscv.2.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune"
+  "cstruct-riscv" 
+  "bigarray-compat-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "io-page" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v2.3.0/io-page-v2.3.0.tbz"
+  checksum: [
+    "sha256=9605a8a03e53bc12682212c371bc477f2a44ed829725ae38cc3005e2f83da2c3"
+    "sha512=ce1775bff151d62bb85405a13fe75f912c11b09cbc0a6dd81dd27b3f4c767f0b9c4d3e7383d494eb5c130311482ea69877c45b71b91153177562ffc47de4da2f"
+  ]
+}


### PR DESCRIPTION
### `io-page-riscv.2.3.0`
Support for efficient handling of I/O memory pages
IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
copying the data contained within the page.



---
* Homepage: https://github.com/mirage/io-page
* Source repo: git+https://github.com/mirage/io-page.git
* Bug tracker: https://github.com/mirage/io-page/issues

---
:camel: Pull-request generated by opam-publish v2.0.0