### PR TITLE
Package mirage-device-riscv.1.2.0

### DIFF
--- a/packages/mirage-device-riscv/mirage-device-riscv.1.2.0/opam
+++ b/packages/mirage-device-riscv/mirage-device-riscv.1.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-device"
+doc: "https://mirage.github.io/mirage-device/"
+bug-reports: "https://github.com/mirage/mirage-device/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv"
+  "fmt-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-device" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-device.git"
+synopsis: "Abstract devices for MirageOS"
+description: """
+mirage-device defines [Mirage_device.S][1], the signature for
+basic abstract devices for MirageOS and a pretty-printing function
+for device errors.
+
+[1]: https://mirage.github.io/mirage-device/Mirage_device.S.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-device/releases/download/v1.2.0/mirage-device-v1.2.0.tbz"
+  checksum: "md5=dac8ccb8064a728fbf55790f02d36b0d"
+}


### PR DESCRIPTION
### `mirage-device-riscv.1.2.0`
Abstract devices for MirageOS
mirage-device defines [Mirage_device.S][1], the signature for
basic abstract devices for MirageOS and a pretty-printing function
for device errors.

[1]: https://mirage.github.io/mirage-device/Mirage_device.S.html



---
* Homepage: https://github.com/mirage/mirage-device
* Source repo: git+https://github.com/mirage/mirage-device.git
* Bug tracker: https://github.com/mirage/mirage-device/issues

---
:camel: Pull-request generated by opam-publish v2.0.0