### PR TITLE
Package mirage-flow-riscv.1.6.0

### DIFF
--- a/packages/mirage-flow-riscv/mirage-flow-riscv.1.6.0/opam
+++ b/packages/mirage-flow-riscv/mirage-flow-riscv.1.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv"
+  "fmt-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-flow" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v1.6.0/mirage-flow-v1.6.0.tbz"
+  checksum: [
+    "sha256=d6596e9bd2442023a3b2222db0a36fd6a97318e06853162c9938d9fab8cc63d3"
+    "sha512=2666268cb4e7208357083a733565e5f07e15ca77bd35b1a00c7fd1562b7abc8e1eb8ec1a5bd5782240993621e6bcaa7003f6143d77b8da09491e5c38b645faeb"
+  ]
+}


### PR DESCRIPTION
### `mirage-flow-riscv.1.6.0`
Flow implementations and combinators for MirageOS
This repo contains generic operations over Mirage `FLOW` implementations.

Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).



---
* Homepage: https://github.com/mirage/mirage-flow
* Source repo: git+https://github.com/mirage/mirage-flow.git
* Bug tracker: https://github.com/mirage/mirage-flow/issues

---
:camel: Pull-request generated by opam-publish v2.0.0