### PR TITLE
Package mirage-clock-riscv.2.0.0

### DIFF
--- a/packages/mirage-clock-riscv/mirage-clock-riscv.2.0.0/opam
+++ b/packages/mirage-clock-riscv/mirage-clock-riscv.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build}
+  "ocaml-riscv"
+  "mirage-device-riscv" 
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-clock" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}


### PR DESCRIPTION
### `mirage-clock-riscv.2.0.0`
Libraries and module types for portable clocks
This library implements portable support for an operating system timesource
that is compatible with the [MirageOS](https://mirage.io) library interfaces
found in: <https://github.com/mirage/mirage>

It implements an `MCLOCK` module that represents a monotonic timesource
since an arbitrary point, and `PCLOCK` which counts time since the Unix
epoch.



---
* Homepage: https://github.com/mirage/mirage-clock
* Source repo: git+https://github.com/mirage/mirage-clock.git
* Bug tracker: https://github.com/mirage/mirage-clock/issues

---
:camel: Pull-request generated by opam-publish v2.0.0