### PR TITLE
Package mirage-clock-lwt-riscv.2.0.0

### DIFF
--- a/packages/mirage-clock-lwt-riscv/mirage-clock-lwt-riscv.2.0.0/opam
+++ b/packages/mirage-clock-lwt-riscv/mirage-clock-lwt-riscv.2.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Lwt-based implementation of the MirageOS Clock interface"
+description: """
+This implementation of the MirageOS CLOCK interface specialises
+the `io` type to use the Lwt concurrency monad.
+"""
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build}
+  "ocaml-riscv"
+  "mirage-clock-riscv" 
+  "lwt-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-clock-lwt" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}


### PR DESCRIPTION
### `mirage-clock-lwt-riscv.2.0.0`
Lwt-based implementation of the MirageOS Clock interface
This implementation of the MirageOS CLOCK interface specialises
the `io` type to use the Lwt concurrency monad.



---
* Homepage: https://github.com/mirage/mirage-clock
* Source repo: git+https://github.com/mirage/mirage-clock.git
* Bug tracker: https://github.com/mirage/mirage-clock/issues

---
:camel: Pull-request generated by opam-publish v2.0.0