### PR TITLE
Package mirage-clock-freestanding-riscv.2.0.0

### DIFF
--- a/packages/mirage-clock-freestanding-riscv/mirage-clock-freestanding-riscv.2.0.0/opam
+++ b/packages/mirage-clock-freestanding-riscv/mirage-clock-freestanding-riscv.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build}
+  "ocaml-riscv"
+  "mirage-clock-riscv" 
+  "mirage-clock-lwt-riscv"
+  "lwt-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-clock-freestanding" "-j" jobs]
+]
+dev-repo: "git://github.com/mirage/mirage-clock"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v2.0.0/mirage-clock-v2.0.0.tbz"
+  checksum: "md5=d51d5ec423bcb13bb03e7ebffc855f6a"
+}


### PR DESCRIPTION
### `mirage-clock-freestanding-riscv.2.0.0`
Paravirtual implementation of the MirageOS Clock interface
This 'freestanding' implementation of the MirageOS CLOCK interface
is designed to be linked against an embedded runtime that provides
a concrete implementation of the clock source. Example implementations
include the [Solo5](https://github.com/solo5/solo5) backend of
MirageOS.



---
* Homepage: https://github.com/mirage/mirage-clock
* Source repo: git://github.com/mirage/mirage-clock
* Bug tracker: https://github.com/mirage/mirage-clock/issues

---
:camel: Pull-request generated by opam-publish v2.0.0