### PR TITLE
Package mirage-time-riscv.1.3.0

### DIFF
--- a/packages/mirage-time-riscv/mirage-time-riscv.1.3.0/opam
+++ b/packages/mirage-time-riscv/mirage-time-riscv.1.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv"
+  "mirage-device-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-time" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS"
+description: """
+mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v1.3.0/mirage-time-v1.3.0.tbz"
+  checksum: [
+    "sha256=8e50db9fa71526468da45790da996589a6331a8f090ed2ba3d5d3607ad67773a"
+    "sha512=e03c27248e32458f55917f9f9b19499bbe3a348fef7db324b85db1961f3d997852b13c73377d17d2b04f204ca51db29ef37279ca1d087fe0fc7e9d086093a17f"
+  ]
+}


### PR DESCRIPTION
### `mirage-time-riscv.1.3.0`
Time operations for MirageOS
mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.



---
* Homepage: https://github.com/mirage/mirage-time
* Source repo: git+https://github.com/mirage/mirage-time.git
* Bug tracker: https://github.com/mirage/mirage-time/issues

---
:camel: Pull-request generated by opam-publish v2.0.0