### PR TITLE
Package mirage-profile-riscv.0.8.2

### DIFF
--- a/packages/mirage-profile-riscv/mirage-profile-riscv.0.8.2/opam
+++ b/packages/mirage-profile-riscv/mirage-profile-riscv.0.8.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+description: """
+Collect runtime profiling information in CTF format
+
+This library can be used to trace execution of OCaml/Lwt programs (such as Mirage unikernels) at the level of Lwt threads.
+The traces can be viewed using JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by tools supporting the [Common Trace Format (CTF)][ctf].
+Some example traces can be found in the blog post [Visualising an Asynchronous Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).
+
+Libraries can use the functions mirage-profile provides to annotate the traces with extra information.
+When compiled against a normal version of Lwt, mirage-profile's functions are null-ops (or call the underlying untraced operation, as appropriate) and OCaml's cross-module inlining will optimise these calls away, meaning there should be no overhead in the non-profiling case. """
+
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+homepage: "https://github.com/mirage/mirage-profile"
+dev-repo: "git+https://github.com/mirage/mirage-profile.git"
+bug-reports: "https://github.com/mirage/mirage-profile/issues"
+doc: "https://mirage.github.io/mirage-profile"
+license: "BSD-2-clause"
+
+build: [
+  [ "jbuilder" "subst"] {pinned}
+  [ "jbuilder" "build" "-x" "riscv" "-p" "mirage-profile" "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {= "4.07.0"}
+  "jbuilder"  {build & >="1.0+beta9"}
+  "cstruct-riscv" {>= "3.0.0"}
+  "ppx_cstruct" {build}
+  "ppx_cstruct-riscv" {build}
+  "ocplib-endian-riscv"
+  "ppx_tools_versioned-riscv"
+  "lwt-riscv"
+  "ocaml-riscv"
+]
+
+url {
+  src:
+    "https://github.com/mirage/mirage-profile/releases/download/v0.8.2/mirage-profile-0.8.2.tbz"
+  checksum: [
+    "md5=7f094bcb0b81746a712326ea583b2e76"
+    "sha512=e66e2ef1129717957e3f08b777f7c5d08c056d8ec027a8b5c34f1555df92574c0f0ab31fa40f7fb660ce4131ddc7618349682bbf170a2d6a25b7746c44ca2eb3"
+  ]
+}
+synopsis: ""


### PR DESCRIPTION
### `mirage-profile-riscv.0.8.2`

Collect runtime profiling information in CTF format

This library can be used to trace execution of OCaml/Lwt programs (such as Mirage unikernels) at the level of Lwt threads.
The traces can be viewed using JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by tools supporting the [Common Trace Format (CTF)][ctf].
Some example traces can be found in the blog post [Visualising an Asynchronous Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).

Libraries can use the functions mirage-profile provides to annotate the traces with extra information.
When compiled against a normal version of Lwt, mirage-profile's functions are null-ops (or call the underlying untraced operation, as appropriate) and OCaml's cross-module inlining will optimise these calls away, meaning there should be no overhead in the non-profiling case.



---
* Homepage: https://github.com/mirage/mirage-profile
* Source repo: git+https://github.com/mirage/mirage-profile.git
* Bug tracker: https://github.com/mirage/mirage-profile/issues

---
:camel: Pull-request generated by opam-publish v2.0.0