### PR TITLE
Package mirage-console-riscv.2.4.3

### DIFF
--- a/packages/mirage-console-riscv/mirage-console-riscv.2.4.3/opam
+++ b/packages/mirage-console-riscv/mirage-console-riscv.2.4.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv"
+  "mirage-device-riscv" 
+  "mirage-flow-riscv" 
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-console" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v2.4.3/mirage-console-v2.4.3.tbz"
+  checksum: [
+    "sha256=9677d51f4075567b488b45ce7f9ee6512fb4f03e72209bb761cc7bd64570cc5b"
+    "sha512=e08a353738bae403418047b19e585543f91f5027c690240d8b3c13b35f62856216d4405ccd758c71ba9c1567638215bb8ef85776965f233ed2ef84d966a1358b"
+  ]
+}


### PR DESCRIPTION
### `mirage-console-riscv.2.4.3`
Implementations of Mirage console devices
This is a general implementation of a console device, intended
for use in MirageOS.



---
* Homepage: https://github.com/mirage/mirage-console
* Source repo: git+https://github.com/mirage/mirage-console.git
* Bug tracker: https://github.com/mirage/mirage-console/issues

---
:camel: Pull-request generated by opam-publish v2.0.0