### PR TITLE
Package mirage-console-lwt-riscv.2.4.3

### DIFF
--- a/packages/mirage-console-lwt-riscv/mirage-console-lwt-riscv.2.4.3/opam
+++ b/packages/mirage-console-lwt-riscv/mirage-console-lwt-riscv.2.4.3/opam
@@ -16,7 +16,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-x " "riscv" "-p" "mirage-console-lwt" "-j" jobs]
+  ["dune" "build" "-x" "riscv" "-p" "mirage-console-lwt" "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-console.git"
 synopsis: "Implementation of Mirage consoles using Lwt"


### PR DESCRIPTION
### `mirage-console-lwt-riscv.2.4.3`
Implementation of Mirage consoles using Lwt
This implements a MirageOS console device using the Lwt
concurrency libary for concurrency.



---
* Homepage: https://github.com/mirage/mirage-console
* Source repo: git+https://github.com/mirage/mirage-console.git
* Bug tracker: https://github.com/mirage/mirage-console/issues

---
:camel: Pull-request generated by opam-publish v2.0.0