### PR TITLE
Package parse-argv-riscv.0.2.0

### DIFF
--- a/packages/parse-argv-riscv/parse-argv-riscv.0.2.0/opam
+++ b/packages/parse-argv-riscv/parse-argv-riscv.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jon Ludlam" "Magnus Skjegstad" "Mindy Preston"]
+tags: "org:mirage"
+homepage: "https://github.com/mirage/parse-argv"
+doc: "https://mirage.github.io/parse-argv/"
+bug-reports: "https://github.com/mirage/parse-argv/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ounit" {with-test}
+  "ocaml-riscv"
+  "astring-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "parse-argv" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/parse-argv.git"
+synopsis: "Process strings into sets of command-line arguments"
+description: """
+parse-argv is a small implementation of a simple argv parser.
+"""
+url {
+  src:
+    "https://github.com/mirage/parse-argv/releases/download/v0.2.0/parse-argv-v0.2.0.tbz"
+  checksum: "md5=0621122768b81e089e5d5ebd7fd2c856"
+}


### PR DESCRIPTION
### `parse-argv-riscv.0.2.0`
Process strings into sets of command-line arguments
parse-argv is a small implementation of a simple argv parser.



---
* Homepage: https://github.com/mirage/parse-argv
* Source repo: git+https://github.com/mirage/parse-argv.git
* Bug tracker: https://github.com/mirage/parse-argv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0