### PR TITLE
Package lwt-dllist-riscv.1.0.0

### DIFF
--- a/packages/lwt-dllist-riscv/lwt-dllist-riscv.1.0.0/opam
+++ b/packages/lwt-dllist-riscv/lwt-dllist-riscv.1.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: [ "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>" ]
+authors: ["Jérôme Vouillon" "Jérémie Dimino"]
+license: "MIT"
+homepage: "https://github.com/mirage/lwt-dllist"
+doc: "https://mirage.github.io/lwt-dllist/"
+bug-reports: "https://github.com/mirage/lwt-dllist/issues"
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build}
+  "ocaml-riscv"
+  "lwt-riscv"
+]
+build: [
+ ["dune" "subst" ] {pinned}
+ ["dune" "build" "-x" "riscv" "-p" "lwt-dllist" "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/lwt-dllist.git"
+synopsis: "Mutable doubly-linked list with Lwt iterators"
+description: """
+A sequence is an object holding a list of elements which support
+the following operations:
+
+- adding an element to the left or the right in time and space O(1)
+- taking an element from the left or the right in time and space O(1)
+- removing a previously added element from a sequence in time and space O(1)
+- removing an element while the sequence is being transversed.
+"""
+url {
+  src:
+    "https://github.com/mirage/lwt-dllist/releases/download/v1.0.0/lwt-dllist-v1.0.0.tbz"
+  checksum: "md5=28959f39bbb96e86776265a836f2e0d5"
+}


### PR DESCRIPTION
### `lwt-dllist-riscv.1.0.0`
Mutable doubly-linked list with Lwt iterators
A sequence is an object holding a list of elements which support
the following operations:

- adding an element to the left or the right in time and space O(1)
- taking an element from the left or the right in time and space O(1)
- removing a previously added element from a sequence in time and space O(1)
- removing an element while the sequence is being transversed.



---
* Homepage: https://github.com/mirage/lwt-dllist
* Source repo: git+https://github.com/mirage/lwt-dllist.git
* Bug tracker: https://github.com/mirage/lwt-dllist/issues

---
:camel: Pull-request generated by opam-publish v2.0.0