### PR TITLE
Package ocb-stubblr-riscv.0.1.1

### DIFF
--- a/packages/ocb-stubblr-riscv/ocb-stubblr-riscv.0.1.1/opam
+++ b/packages/ocb-stubblr-riscv/ocb-stubblr-riscv.0.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "astring-riscv"
 ]
 
-build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "--toolchain" "riscv"]
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "ocb-stubblr.install"]]
 
 synopsis: "OCamlbuild plugin for C stubs"


### PR DESCRIPTION
### `ocb-stubblr-riscv.0.1.1`
OCamlbuild plugin for C stubs
Do you get excited by C stubs? Do they sometimes make you swoon, and even faint,
and in the end no `cmxa`s get properly linked -- not to mention correct
multi-lib support?

Do you wish that the things that excite you the most, would excite you just a
little less? Then ocb-stubblr is just the library for you.

ocb-stubblr is about ten lines of code that you need to repeat over, over, over
and over again if you are using `ocamlbuild` to build OCaml projects that
contain C stubs -- now with 100% more lib!

It does what everyone wants to do with `.clib` files in their project
directories. It can also clone the `.clib` and arrange for multiple compilations
with different sets of discovered `cflags`.

ocb-stubblr is distributed under the ISC license.



---
* Homepage: https://github.com/pqwy/ocb-stubblr
* Source repo: git+https://github.com/pqwy/ocb-stubblr.git
* Bug tracker: https://github.com/pqwy/ocb-stubblr/issues

---
:camel: Pull-request generated by opam-publish v2.0.0