### PR TITLE
Package ppx_cstruct-riscv.5.0.0

### DIFF
--- a/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
+++ b/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "ppx_cstruct" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.08.0"}
+]
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {>= "1.0"}
+  "ocaml-riscv"
+  "cstruct-riscv" 
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
+  "ppx_sexp_conv" {with-test & < "v0.13"}
+  "sexplib-riscv" {< "v0.13"}
+  "cstruct-sexp" {with-test}
+  "cstruct-unix" {with-test & =version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v5.0.0/cstruct-v5.0.0.tbz"
+  checksum: [
+    "sha256=eb8a4e4438ca4ab59e9d98ca70177edd8b590136fe7a200fe8e5bf69051e80fc"
+    "sha512=414c2c780200252b5ebf16dd4fd1db28ffa483dba5be1c0092e08327d1d870f688c6f671892dcd8bbcf579f56e3d27b345ec0a96209fb25c0a984825b2e144f5"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstruct-riscv.5.0.0`
Access C-like structures directly from OCaml
Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml.  It supports both reading and writing to these
structures, and they are accessed via the `Bigarray` module.



---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: git+https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---
:camel: Pull-request generated by opam-publish v2.0.0