### PR TITLE
Package ppx_derivers-riscv.1.2.1

### DIFF
--- a/packages/ppx_derivers-riscv/ppx_derivers-riscv.1.2.1/opam
+++ b/packages/ppx_derivers-riscv/ppx_derivers-riscv.1.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["Jérémie Dimino"]
+license: "BSD3"
+homepage: "https://github.com/ocaml-ppx/ppx_derivers"
+bug-reports: "https://github.com/ocaml-ppx/ppx_derivers/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_derivers.git"
+build: [
+  ["dune" "build" "-p" "ppx_derivers" "-j" jobs]
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_derivers"]]
+depends: [
+  "ocaml"
+  "dune"
+  "ocaml-riscv"
+]
+synopsis: "Shared [@@deriving] plugin registry"
+description: """
+Ppx_derivers is a tiny package whose sole purpose is to allow
+ppx_deriving and ppx_type_conv to inter-operate gracefully when linked
+as part of the same ocaml-migrate-parsetree driver."""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz"
+  checksum: "md5=5dc2bf130c1db3c731fe0fffc5648b41"
+}


### PR DESCRIPTION
### `ppx_derivers-riscv.1.2.1`
Shared [@@deriving] plugin registry
Ppx_derivers is a tiny package whose sole purpose is to allow
ppx_deriving and ppx_type_conv to inter-operate gracefully when linked
as part of the same ocaml-migrate-parsetree driver.



---
* Homepage: https://github.com/ocaml-ppx/ppx_derivers
* Source repo: git://github.com/ocaml-ppx/ppx_derivers.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_derivers/issues

---
:camel: Pull-request generated by opam-publish v2.0.0