### PR TITLE
Package ppx_cstruct-riscv.5.0.0

### DIFF
--- a/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
+++ b/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
@@ -20,12 +20,12 @@ depends: [
   "ocaml" {= "4.07.0"}
   "dune" {>= "1.0"}
   "ocaml"
-  "cstruct-riscv" 
+  "cstruct" 
   "ounit" {with-test}
-  "ppx_tools_versioned-riscv" {>= "5.0.1"}
-  "ocaml-migrate-parsetree-riscv"
+  "ppx_tools_versioned" {>= "5.0.1"}
+  "ocaml-migrate-parsetree"
   "ppx_sexp_conv" {with-test & < "v0.13"}
-  "sexplib-riscv" {< "v0.13"}
+  "sexplib" {< "v0.13"}
   "cstruct-sexp" {with-test}
   "cstruct-unix" {with-test & =version}
 ]


### PR DESCRIPTION
### `ppx_cstruct-riscv.5.0.0`
Access C-like structures directly from OCaml
Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml.  It supports both reading and writing to these
structures, and they are accessed via the `Bigarray` module.



---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: git+https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---
:camel: Pull-request generated by opam-publish v2.0.0