### PR TITLE
Package ppx_cstruct-riscv.5.0.0

### DIFF
--- a/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
+++ b/packages/ppx_cstruct-riscv/ppx_cstruct-riscv.5.0.0/opam
@@ -15,7 +15,7 @@ build: [
   ["dune" "build" "-p" "ppx_cstruct" "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.08.0"}
 ]
-install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_derivers"]]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_cstruct"]]
 depends: [
   "ocaml" {= "4.07.0"}
   "dune" {>= "1.0"}


### PR DESCRIPTION
### `ppx_cstruct-riscv.5.0.0`
Access C-like structures directly from OCaml
Cstruct is a library and syntax extension to make it easier to access C-like
structures directly from OCaml.  It supports both reading and writing to these
structures, and they are accessed via the `Bigarray` module.



---
* Homepage: https://github.com/mirage/ocaml-cstruct
* Source repo: git+https://github.com/mirage/ocaml-cstruct.git
* Bug tracker: https://github.com/mirage/ocaml-cstruct/issues

---
:camel: Pull-request generated by opam-publish v2.0.0