### PR TITLE
Package mirage-profile-riscv.0.9.1

### DIFF
--- a/packages/mirage-profile-riscv/mirage-profile-riscv.0.9.1/opam
+++ b/packages/mirage-profile-riscv/mirage-profile-riscv.0.9.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-profile/issues"
 depends: [
   "ocaml" {= "4.07.0"}
   "dune" {build & >= "1.0"}
-  "ppx_cstruct-riscv" {build}
+  "ppx_cstruct" {build}
   "ocaml-riscv"
   "cstruct-riscv"
   "ocplib-endian-riscv"


### PR DESCRIPTION
### `mirage-profile-riscv.0.9.1`
Collect runtime profiling information in CTF format
This library can be used to trace execution of OCaml/Lwt programs (such as
Mirage unikernels) at the level of Lwt threads.  The traces can be viewed using
JavaScript or GTK viewers provided by [mirage-trace-viewer][] or processed by
tools supporting the [Common Trace Format (CTF)][ctf].  Some example traces can
be found in the blog post [Visualising an Asynchronous
Monad](http://roscidus.com/blog/blog/2014/10/27/visualising-an-asynchronous-monad/).

Libraries can use the functions mirage-profile provides to annotate the traces
with extra information.  When compiled against a normal version of Lwt,
mirage-profile's functions are null-ops (or call the underlying untraced
operation, as appropriate) and OCaml's cross-module inlining will optimise
these calls away, meaning there should be no overhead in the non-profiling
case.



---
* Homepage: https://github.com/mirage/mirage-profile
* Source repo: git+https://github.com/mirage/mirage-profile.git
* Bug tracker: https://github.com/mirage/mirage-profile/issues

---
:camel: Pull-request generated by opam-publish v2.0.0