### PR TITLE
Package ocaml-migrate-parsetree-riscv.1.4.0

### DIFF
--- a/packages/ocaml-migrate-parsetree-riscv/ocaml-migrate-parsetree-riscv.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree-riscv/ocaml-migrate-parsetree-riscv.1.4.0/opam
@@ -13,7 +13,7 @@ tags: [ "syntax" "org:ocamllabs" ]
 build: [
   ["dune" "build" "-p" "ocaml-migrate-parsetree" "-j" jobs]
 ]
-
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ocaml-migrate-parsetree"]]
 depends: [
   "result"
   "ppx_derivers"


### PR DESCRIPTION
### `ocaml-migrate-parsetree-riscv.1.4.0`
Convert OCaml parsetrees between different versions
Convert OCaml parsetrees between different versions

This library converts parsetrees, outcometree and ast mappers between
different OCaml versions.  High-level functions help making PPX
rewriters independent of a compiler version.



---
* Homepage: https://github.com/ocaml-ppx/ocaml-migrate-parsetree
* Source repo: git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues

---
:camel: Pull-request generated by opam-publish v2.0.0