### PR TITLE
Package ppx_tools_versioned-riscv.5.2.3

### DIFF
--- a/packages/ppx_tools_versioned-riscv/ppx_tools_versioned-riscv.5.2.3/opam
+++ b/packages/ppx_tools_versioned-riscv/ppx_tools_versioned-riscv.5.2.3/opam
@@ -18,7 +18,7 @@ install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_tools_versi
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "1.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree-riscv" {>= "1.4.0"}
   "ocaml-riscv"
 ]
 synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"


### PR DESCRIPTION
### `ppx_tools_versioned-riscv.5.2.3`
A variant of ppx_tools based on ocaml-migrate-parsetree



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools_versioned
* Source repo: git://github.com/ocaml-ppx/ppx_tools_versioned.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools_versioned/issues

---
:camel: Pull-request generated by opam-publish v2.0.0