### PR TITLE
Package ppx_tools_versioned-riscv.5.2.2

### DIFF
--- a/packages/ppx_tools_versioned-riscv/ppx_tools_versioned-riscv.5.2.2/opam
+++ b/packages/ppx_tools_versioned-riscv/ppx_tools_versioned-riscv.5.2.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Alain Frisch <alain.frisch@lexifi.com>"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools_versioned"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools_versioned/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools_versioned.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" "ppx_tools_versioned" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_tools_versioned"]]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "1.0"}
+  "ocaml-migrate-parsetree"
+  "ocaml-riscv"
+]
+synopsis: "A variant of ppx_tools based on ocaml-migrate-parsetree"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_tools_versioned/archive/5.2.2.tar.gz"
+  checksum: [
+    "md5=b1455e5a4a1bcd9ddbfcf712ccbd4262"
+    "sha512=af20aa0031b9c638537bcdb52c75de95f316ae8fd455a38672a60da5c7c6895cca9dbecd5d56a88c3c40979c6a673a047d986b5b41e1e84b528b7df5d905b9b1"
+  ]
+}


### PR DESCRIPTION
### `ppx_tools_versioned-riscv.5.2.2`
A variant of ppx_tools based on ocaml-migrate-parsetree



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools_versioned
* Source repo: git://github.com/ocaml-ppx/ppx_tools_versioned.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools_versioned/issues

---
:camel: Pull-request generated by opam-publish v2.0.0