### PR TITLE
Package mirage-block-riscv.1.2.0

### DIFF
--- a/packages/mirage-block-riscv/mirage-block-riscv.1.2.0/opam
+++ b/packages/mirage-block-riscv/mirage-block-riscv.1.2.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-device-riscv" 
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-block" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v1.2.0/mirage-block-v1.2.0.tbz"
+  checksum: "md5=429022b9e477e8cd99b5906f073c59f4"
+}


### PR DESCRIPTION
### `mirage-block-riscv.1.2.0`
Block signatures and implementations for MirageOS
This repo contains generic operations over Mirage `BLOCK` devices.



---
* Homepage: https://github.com/mirage/mirage-block
* Source repo: git+https://github.com/mirage/mirage-block.git
* Bug tracker: https://github.com/mirage/mirage-block/issues

---
:camel: Pull-request generated by opam-publish v2.0.0