### PR TITLE
Package mirage-fs-riscv.2.0.0

### DIFF
--- a/packages/mirage-fs-riscv/mirage-fs-riscv.2.0.0/opam
+++ b/packages/mirage-fs-riscv/mirage-fs-riscv.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-fs" "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "fmt-riscv"
+  "mirage-device-riscv" {>= "1.0.0"}
+]
+
+synopsis: "MirageOS signatures for filesystem devices"
+description: """
+mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
+the MirageOS filesystem devices should implement.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-fs/releases/download/v2.0.0/mirage-fs-v2.0.0.tbz"
+  checksum: "md5=b391694a35550ca52439562a31577bb6"
+}


### PR DESCRIPTION
### `mirage-fs-riscv.2.0.0`
MirageOS signatures for filesystem devices
mirage-fs provides the `[Mirage_fs.S][fs]` and `[Mirage_fs_lwt.S]` signatures
the MirageOS filesystem devices should implement.

[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
[fslwt]: http://mirage.github.io/mirage-fs/Mirage_fs_lwt.html



---
* Homepage: https://github.com/mirage/mirage-fs
* Source repo: git+https://github.com/mirage/mirage-fs.git
* Bug tracker: https://github.com/mirage/mirage-fs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0