### PR TITLE
Package uchar-riscv.0.0.2

### DIFF
--- a/packages/uchar-riscv/uchar-riscv.0.0.2/opam
+++ b/packages/uchar-riscv/uchar-riscv.0.0.2/opam
@@ -24,8 +24,8 @@ depends: [
 build:
 [
   [ "ocaml" "pkg/git.ml" ]
-  [ "env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "pkg/build.ml"  "native=false"
-                            "native-dynlink=false"]
+#  [ "env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "pkg/build.ml"  "native=false" "native-dynlink=false"]
+  [ "env" "OCAMLFIND_TOOLCHAIN=riscv" "ocaml" "pkg/build.ml" ]
 ]
 install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "uchar.install"]]
 url {


### PR DESCRIPTION
### `uchar-riscv.0.0.2`

Compatibility library for OCaml's Uchar module

The `uchar` package provides a compatibility library for the
[`Uchar`][1] module introduced in OCaml 4.03.

The `uchar` package is distributed under the license of the OCaml
compiler. See [LICENSE](LICENSE) for details.
[1]: http://caml.inria.fr/pub/docs/manual-ocaml/libref/Uchar.html



---
* Homepage: http://ocaml.org
* Source repo: git+https://github.com/ocaml/uchar.git
* Bug tracker: https://github.com/ocaml/uchar/issues

---
:camel: Pull-request generated by opam-publish v2.0.0