### PR TITLE
Package ocaml-boot-riscv.0.1

### DIFF
--- a/packages/ocaml-boot-riscv/ocaml-boot-riscv.0.1/opam
+++ b/packages/ocaml-boot-riscv/ocaml-boot-riscv.0.1/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "0.1"
 maintainer: [
 	"Malte Bargholz <malte@screenri.de>"
 	"Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>" 
@@ -21,8 +20,11 @@ depends: [
 synopsis: "Core package for booting anything on riscv"
 description:
   "This package provides a bootlayer to the ocaml-freestanding runtime on the RISC-V/SHAKTI architecture"
-
 url {
-	src: "https://codeload.github.com/mirage-shakti-iitm/ocaml-boot-riscv/tar.gz/v0.1"
-	checksum: "md5=edeb5612ba98061ac552f1d3f10b3ebf"
+  src:
+    "https://github.com/mirage-shakti-iitm/ocaml-boot-riscv/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=edeb5612ba98061ac552f1d3f10b3ebf"
+    "sha512=73d52ad3f7cad8efebfafad4ce3c965a3a6d5d3dbbb3bf44e3bf693bd3e00324bc833396ca322544befc38e7222d55b68bfb4380c9a36c56b48cb8d039604f48"
+  ]
 }


### PR DESCRIPTION
### `ocaml-boot-riscv.0.1`
Core package for booting anything on riscv
This package provides a bootlayer to the ocaml-freestanding runtime on the RISC-V/SHAKTI architecture



---
* Homepage: https://gitlab.com/shaktiproject/tools/shakti-tee/ocaml-boot-riscv
* Source repo: git+https://gitlab.com/shaktiproject/tools/shakti-tee/ocaml-boot-riscv.git#mirage
* Bug tracker: https://gitlab.com/shaktiproject/tools/shakti-tee/ocaml-boot-riscv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0