### PR TITLE
Package mirage-riscv.0.5.0

### DIFF
--- a/packages/mirage-riscv/mirage-riscv.0.5.0/opam
+++ b/packages/mirage-riscv/mirage-riscv.0.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: [
+  "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+   "Malte Bargholz <malte@screenri.de>"
+]
+homepage:     "https://github.com/mirage-shakti-iitm/mirage-riscv"
+bug-reports:  "https://github.com/mirage-shakti-iitm/mirage-riscv/issues/"
+dev-repo:     "git+https://github.com/mirage-shakti-iitm/mirage-riscv.git"
+license:      "ISC"
+authors: [
+  "Malte Bargholz <malte@screenri.de>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+     [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--toolchain" "riscv"]
+]
+install: [["opam-installer" "--prefix=%{prefix}%/riscv-sysroot" "mirage-riscv.install"]]
+
+depends: [
+  "ocaml" {= "4.07.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+  "ocaml-riscv"
+  "bheap-riscv"
+  "ocb-stubblr" {build}
+  "cstruct-riscv"
+  "lwt-riscv" 
+  "lwt-dllist-riscv"
+  "ocaml-freestanding-riscv"
+  "logs-riscv"
+  "ocaml-boot-riscv"
+]
+conflicts: [
+  "io-page-riscv" {< "2.0.0"}
+]
+synopsis: "RISC-V core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+RISC-V targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage-shakti-iitm/mirage-riscv/archive/v0.5.0.tar.gz"
+  checksum: [
+    "md5=80364c71f82442a124bd1be8a9c224f9"
+    "sha512=aa57514185aa3ebdd4345a88fdb4ab215fc5b9441b5d4b1715c59a81e75851a4972bd73406993b5b37a0a360260a258d4ff008aebf97f9951e94581de5d72468"
+  ]
+}


### PR DESCRIPTION
### `mirage-riscv.0.5.0`
RISC-V core platform libraries for MirageOS
This package provides the MirageOS `OS` library for
RISC-V targets, which handles the main loop
and timers. It also provides the low level C startup code and C stubs required
by the OCaml code.

The OCaml runtime and C runtime required to support it are provided separately
by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.



---
* Homepage: https://github.com/mirage-shakti-iitm/mirage-riscv
* Source repo: git+https://github.com/mirage-shakti-iitm/mirage-riscv.git
* Bug tracker: https://github.com/mirage-shakti-iitm/mirage-riscv/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0