### PR TITLE
Package ocaml-freestanding-riscv.0.4.2

### DIFF
--- a/packages/ocaml-freestanding-riscv/ocaml-freestanding-riscv.0.4.2/opam
+++ b/packages/ocaml-freestanding-riscv/ocaml-freestanding-riscv.0.4.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [
+  ["env" "BUILD_ARCH=riscv64" "PKG_CONFIG_PATH=%{prefix}%/share/pkgconfig" "./configure.sh"]
+  ["env" "BUILD_ARCH=riscv64" "PKG_CONFIG_PATH=%{prefix}%/share/pkgconfig" make]
+]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src-riscv" {build}
+  "ocaml" {= "4.07.0"}
+  "ocaml-riscv"
+  "ocaml-boot-riscv"
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+substs: [
+  "cflags.tmp"
+  "libs.tmp"
+]
+extra-files: [
+  ["cflags.tmp.in" "md5=a5cc9f5c04e5d96b0f2b6f62f8a165e1"]
+  ["libs.tmp.in" "md5=30bd7458eb618332e03406b3de9908a6"]
+] 
+synopsis: "Freestanding OCaml runtime"
+description:
+  "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer. Modified for RiscV"
+
+#"OCAML_SRC_DIR=%{prefix}%/riscv-sysroot/lib/ocaml-src-riscv"
+url {
+  src:
+    "https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv/archive/v0.4.2.tar.gz"
+  checksum: [
+    "md5=10a823399a742fa7bca3eeb3f40ac9f1"
+    "sha512=e5e3c7822aef656e2803b844841dbb9dc8751de2f8c30635456c4039901b282d83a1485967ddd2cd61fa29cc92f6538a35f32daa3bb71af2d40b8ff2470a0e39"
+  ]
+}


### PR DESCRIPTION
### `ocaml-freestanding-riscv.0.4.2`
Freestanding OCaml runtime
This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer. Modified for RiscV



---
* Homepage: https://github.com/mirage/ocaml-freestanding
* Source repo: git+https://github.com/mirage/ocaml-freestanding.git
* Bug tracker: https://github.com/mirage/ocaml-freestanding/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0