### PR TITLE
Package ocaml-freestanding-riscv.0.4.2

### DIFF
--- a/packages/ocaml-freestanding-riscv/ocaml-freestanding-riscv.0.4.2/opam
+++ b/packages/ocaml-freestanding-riscv/ocaml-freestanding-riscv.0.4.2/opam
@@ -1,11 +1,11 @@
 opam-version: "2.0"
 maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
 authors: "Martin Lucina <martin@lucina.net>"
-homepage: "https://github.com/mirage/ocaml-freestanding"
-bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+homepage: "https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv"
+bug-reports: "https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscvissues/"
 license: "MIT"
 tags: "org:mirage"
-dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+dev-repo: "git+https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv.git"
 build: [
   ["env" "BUILD_ARCH=riscv64" "PKG_CONFIG_PATH=%{prefix}%/share/pkgconfig" "./configure.sh"]
   ["env" "BUILD_ARCH=riscv64" "PKG_CONFIG_PATH=%{prefix}%/share/pkgconfig" make]
@@ -37,13 +37,11 @@ extra-files: [
 synopsis: "Freestanding OCaml runtime"
 description:
   "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer. Modified for RiscV"
-
-#"OCAML_SRC_DIR=%{prefix}%/riscv-sysroot/lib/ocaml-src-riscv"
 url {
   src:
     "https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv/archive/v0.4.2.tar.gz"
   checksum: [
-    "md5=10a823399a742fa7bca3eeb3f40ac9f1"
-    "sha512=e5e3c7822aef656e2803b844841dbb9dc8751de2f8c30635456c4039901b282d83a1485967ddd2cd61fa29cc92f6538a35f32daa3bb71af2d40b8ff2470a0e39"
+    "md5=579e75d331d30d23e043e9a9edc78b19"
+    "sha512=8d6020223359e7727c888a68c98262a4a469eb82badab8a49d4ef9a30ae21ea64fca37220937c74d086b13f92223a049563eaa953d64992e1534500a20f3d728"
   ]
 }


### PR DESCRIPTION
### `ocaml-freestanding-riscv.0.4.2`
Freestanding OCaml runtime
This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer. Modified for RiscV



---
* Homepage: https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv
* Source repo: git+https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscv.git
* Bug tracker: https://github.com/mirage-shakti-iitm/ocaml-freestanding-riscvissues/

---
:camel: Pull-request generated by opam-publish v2.0.0