### PR TITLE
Package ocaml-compiler-libs-riscv.0.12.1

### DIFF
--- a/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.0.12.1/opam
+++ b/packages/ocaml-compiler-libs-riscv/ocaml-compiler-libs-riscv.0.12.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
 license: "Apache-2.0"
 build: [
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" "ocaml-compiler-libs" "-j" jobs]
 ]
 install: [
   ["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ocaml-compiler-libs"] 


### PR DESCRIPTION
### `ocaml-compiler-libs-riscv.0.12.1`
OCaml compiler libraries repackaged
This packages exposes the OCaml compiler libraries repackages under
the toplevel names Ocaml_common, Ocaml_bytecomp, Ocaml_optcomp, ...



---
* Homepage: https://github.com/janestreet/ocaml-compiler-libs
* Source repo: git+https://github.com/janestreet/ocaml-compiler-libs.git
* Bug tracker: https://github.com/janestreet/ocaml-compiler-libs/issues

---
:camel: Pull-request generated by opam-publish v2.0.0