### PR TITLE
Package ppxlib-riscv.0.8.1

### DIFF
--- a/packages/ppxlib-riscv/ppxlib-riscv.0.8.1/opam
+++ b/packages/ppxlib-riscv/ppxlib-riscv.0.8.1/opam
@@ -8,13 +8,13 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 license: "MIT"
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" "ppxlib" "-j" jobs]
 ]
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 install: [
-  ["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ocaml-compiler-libs"] 
+  ["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppxlib"] 
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}


### PR DESCRIPTION
### `ppxlib-riscv.0.8.1`
Base library and tools for ppx rewriters
A comprehensive toolbox for ppx development. It features:
- a OCaml AST / parser / pretty-printer snapshot,to create a full
   frontend independent of the version of OCaml;
- a library for library for ppx rewriters in general, and type-driven
  code generators in particular;
- a feature-full driver for OCaml AST transformers;
- a quotation mechanism allowing  to write values representing the
   OCaml AST in the OCaml syntax;
- a generator of open recursion classes from type definitions.



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: git+https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0