### PR TITLE
Package ppx_fields_conv-riscv.0.12.0

### DIFF
--- a/packages/ppx_fields_conv-riscv/ppx_fields_conv-riscv.0.12.0/opam
+++ b/packages/ppx_fields_conv-riscv/ppx_fields_conv-riscv.0.12.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_fields_conv"
+bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_fields_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_fields_conv" "-j" jobs]
+]
+install: [
+  ["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_fields_conv"] 
+]
+depends: [
+  "ocaml"     {>= "4.04.2"}
+  "base"      {>= "v0.12" & < "v0.13"}
+  "fieldslib" {>= "v0.12" & < "v0.13"}
+  "dune"      {>= "1.5.1"}
+  "ppxlib"    {>= "0.5.0" & < "0.9.0"}
+]
+synopsis: "Generation of accessor and iteration functions for ocaml records"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_fields_conv-v0.12.0.tar.gz"
+  checksum: "md5=5bdf701197abc0dd4145a489912e49aa"
+}


### PR DESCRIPTION
### `ppx_fields_conv-riscv.0.12.0`
Generation of accessor and iteration functions for ocaml records
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_fields_conv
* Source repo: git+https://github.com/janestreet/ppx_fields_conv.git
* Bug tracker: https://github.com/janestreet/ppx_fields_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0