### PR TITLE
Package ppx_inline_test-riscv.0.12.0

### DIFF
--- a/packages/ppx_inline_test-riscv/ppx_inline_test-riscv.0.12.0/opam
+++ b/packages/ppx_inline_test-riscv/ppx_inline_test-riscv.0.12.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_inline_test" "-j" jobs]
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_inline_test"]]
+depends: [
+  "ocaml"  {>= "4.04.2"}
+  "base"   {>= "v0.12" & < "v0.13"}
+  "dune"   {>= "1.5.1"}
+  "ppxlib" {>= "0.5.0" & < "0.9.0"}
+]
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_inline_test-v0.12.0.tar.gz"
+  checksum: "md5=b9d2642f627b9b72b13a14ae33ec7c2f"
+}


### PR DESCRIPTION
### `ppx_inline_test-riscv.0.12.0`
Syntax extension for writing in-line tests in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_inline_test
* Source repo: git+https://github.com/janestreet/ppx_inline_test.git
* Bug tracker: https://github.com/janestreet/ppx_inline_test/issues

---
:camel: Pull-request generated by opam-publish v2.0.0