### PR TITLE
Package ppx_fields_conv-riscv.0.12.0

### DIFF
--- a/packages/ppx_fields_conv-riscv/ppx_fields_conv-riscv.0.12.0/opam
+++ b/packages/ppx_fields_conv-riscv/ppx_fields_conv-riscv.0.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "base"      {>= "v0.12" & < "v0.13"}
   "fieldslib" {>= "v0.12" & < "v0.13"}
   "dune"      {>= "1.5.1"}
-  "ppxlib"    {>= "0.5.0" & < "0.9.0"}
+  "ppxlib-riscv"    {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "


### PR DESCRIPTION
### `ppx_fields_conv-riscv.0.12.0`
Generation of accessor and iteration functions for ocaml records
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_fields_conv
* Source repo: git+https://github.com/janestreet/ppx_fields_conv.git
* Bug tracker: https://github.com/janestreet/ppx_fields_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0