### PR TITLE
Package ppxlib-riscv.0.8.1

### DIFF
--- a/packages/ppxlib-riscv/ppxlib-riscv.0.8.1/opam
+++ b/packages/ppxlib-riscv/ppxlib-riscv.0.8.1/opam
@@ -18,12 +18,12 @@ install: [
 ]
 depends: [
   "ocaml"                   {>= "4.04.1"}
-  "base"                    {>= "v0.11.0"}
+  "base-nat-riscv"                    {>= "v0.11.0"}
   "dune"
-  "ocaml-compiler-libs"     {>= "v0.11.0"}
-  "ocaml-migrate-parsetree" {>= "1.3.1"}
-  "ppx_derivers"            {>= "1.0"}
-  "stdio"                   {>= "v0.11.0"}
+  "ocaml-compiler-libs-riscv"     {>= "v0.11.0"}
+  "ocaml-migrate-parsetree-riscv" {>= "1.3.1"}
+  "ppx_derivers-riscv"            {>= "1.0"}
+  "stdio-nat-riscv"                   {>= "v0.11.0"}
   "ocamlfind"               {with-test}
 ]
 synopsis: "Base library and tools for ppx rewriters"


### PR DESCRIPTION
### `ppxlib-riscv.0.8.1`
Base library and tools for ppx rewriters
A comprehensive toolbox for ppx development. It features:
- a OCaml AST / parser / pretty-printer snapshot,to create a full
   frontend independent of the version of OCaml;
- a library for library for ppx rewriters in general, and type-driven
  code generators in particular;
- a feature-full driver for OCaml AST transformers;
- a quotation mechanism allowing  to write values representing the
   OCaml AST in the OCaml syntax;
- a generator of open recursion classes from type definitions.



---
* Homepage: https://github.com/ocaml-ppx/ppxlib
* Source repo: git+https://github.com/ocaml-ppx/ppxlib.git
* Bug tracker: https://github.com/ocaml-ppx/ppxlib/issues

---
:camel: Pull-request generated by opam-publish v2.0.0