### PR TITLE
Package ppx_inline_test-riscv.0.12.0

### DIFF
--- a/packages/ppx_inline_test-riscv/ppx_inline_test-riscv.0.12.0/opam
+++ b/packages/ppx_inline_test-riscv/ppx_inline_test-riscv.0.12.0/opam
@@ -12,9 +12,9 @@ build: [
 install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_inline_test"]]
 depends: [
   "ocaml"  {>= "4.04.2"}
-  "base"   {>= "v0.12" & < "v0.13"}
+  "base-nat-riscv"
   "dune"   {>= "1.5.1"}
-  "ppxlib" {>= "0.5.0" & < "0.9.0"}
+  "ppxlib-riscv" {>= "0.5.0" & < "0.9.0"}
 ]
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "


### PR DESCRIPTION
### `ppx_inline_test-riscv.0.12.0`
Syntax extension for writing in-line tests in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_inline_test
* Source repo: git+https://github.com/janestreet/ppx_inline_test.git
* Bug tracker: https://github.com/janestreet/ppx_inline_test/issues

---
:camel: Pull-request generated by opam-publish v2.0.0