### PR TITLE
Package ocaml-migrate-parsetree-riscv.1.4.0

### DIFF
--- a/packages/ocaml-migrate-parsetree-riscv/ocaml-migrate-parsetree-riscv.1.4.0/opam
+++ b/packages/ocaml-migrate-parsetree-riscv/ocaml-migrate-parsetree-riscv.1.4.0/opam
@@ -16,7 +16,8 @@ build: [
 install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ocaml-migrate-parsetree"]]
 depends: [
   "result"
-  "ppx_derivers"
+  "result-riscv"
+  "ppx_derivers-riscv"
   "dune" {>= "1.9.0"}
   "ocaml" {>= "4.02.3"}
 ]


### PR DESCRIPTION
### `ocaml-migrate-parsetree-riscv.1.4.0`
Convert OCaml parsetrees between different versions
Convert OCaml parsetrees between different versions

This library converts parsetrees, outcometree and ast mappers between
different OCaml versions.  High-level functions help making PPX
rewriters independent of a compiler version.



---
* Homepage: https://github.com/ocaml-ppx/ocaml-migrate-parsetree
* Source repo: git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git
* Bug tracker: https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues

---
:camel: Pull-request generated by opam-publish v2.0.0