### PR TITLE
Package cppo-riscv.1.6.6

### DIFF
--- a/packages/cppo-riscv/cppo-riscv.1.6.6/opam
+++ b/packages/cppo-riscv/cppo-riscv.1.6.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "http://mjambon.com/cppo.html"
+doc: "https://ocaml-community.github.io/cppo/"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+description: """
+Cppo is an equivalent of the C preprocessor for OCaml programs.
+It allows the definition of simple macros and file inclusion.
+
+Cppo is:
+
+* more OCaml-friendly than cpp
+* easy to learn without consulting a manual
+* reasonably fast
+* simple to install and to maintain
+"""
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+synopsis: "Code preprocessor like cpp for OCaml"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" "cppo" "-j" jobs]
+  ["dune" "runtest" "-p" "cppo" "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {= "4.07.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv" 
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "cppo"]]
+url {
+  src: "https://github.com/ocaml-community/cppo/releases/download/v1.6.6/cppo-v1.6.6.tbz"
+  checksum: [
+    "sha256=e7272996a7789175b87bb998efd079794a8db6625aae990d73f7b4484a07b8a0"
+    "sha512=44ecf9d225d9e45490a2feac0bde04865ca398dba6c3579e3370fcd1ea255707b8883590852af8b2df87123801062b9f3acce2455c092deabf431f9c4fb8d8eb"
+  ]
+}


### PR DESCRIPTION
### `cppo-riscv.1.6.6`
Code preprocessor like cpp for OCaml
Cppo is an equivalent of the C preprocessor for OCaml programs.
It allows the definition of simple macros and file inclusion.

Cppo is:

* more OCaml-friendly than cpp
* easy to learn without consulting a manual
* reasonably fast
* simple to install and to maintain



---
* Homepage: http://mjambon.com/cppo.html
* Source repo: git+https://github.com/ocaml-community/cppo.git
* Bug tracker: https://github.com/ocaml-community/cppo/issues

---
:camel: Pull-request generated by opam-publish v2.0.0