### PR TITLE
Package ppx_sexp_conv-riscv.0.12.0

### DIFF
--- a/packages/ppx_sexp_conv-riscv/ppx_sexp_conv-riscv.0.12.0/opam
+++ b/packages/ppx_sexp_conv-riscv/ppx_sexp_conv-riscv.0.12.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" "ppx_sexp_conv" "-j" jobs]
+]
+install: [["dune" "install" "--prefix=%{prefix}%/riscv-sysroot" "ppx_sexp_conv"]]
+depends: [
+  "ocaml"    {>= "4.04.2"}
+  "base-nat-riscv" 
+  "sexplib0-riscv" 
+  "dune"     {>= "1.5.1"}
+  "ppxlib-riscv"   
+]
+synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/ppx_sexp_conv-v0.12.0.tar.gz"
+  checksum: "md5=648ac430b4a74c2297705d260b66778f"
+}


### PR DESCRIPTION
### `ppx_sexp_conv-riscv.0.12.0`
[@@deriving] plugin to generate S-expression conversion functions
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_sexp_conv
* Source repo: git+https://github.com/janestreet/ppx_sexp_conv.git
* Bug tracker: https://github.com/janestreet/ppx_sexp_conv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0