### PR TITLE
Package ipaddr-sexp-riscv.4.0.0

### DIFF
--- a/packages/ipaddr-sexp-riscv/ipaddr-sexp-riscv.4.0.0/opam
+++ b/packages/ipaddr-sexp-riscv/ipaddr-sexp-riscv.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations usnig sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "ipaddr-riscv"
+  "ipaddr-cstruct" {with-test}
+  "ounit" {with-test}
+  "ppx_sexp_conv-riscv" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "ipaddr-sexp" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v4.0.0/ipaddr-v4.0.0.tbz"
+  checksum: [
+    "sha256=6f4abf9c210b20ccddf4610691a87b8c870790d8f71d4a7edcfca9e21b59fc29"
+    "sha512=ca55a8cfa8b84c0a2f4e1fe7afb4c582066bbb562efb94169c0347e441ce076dc426d191772edb869eca6bd77f42f7141378181057ad8886da25ef915a9ee57f"
+  ]
+}


### PR DESCRIPTION
### `ipaddr-sexp-riscv.4.0.0`
A library for manipulation of IP address representations usnig sexp
Sexp convertions for ipaddr



---
* Homepage: https://github.com/mirage/ocaml-ipaddr
* Source repo: git+https://github.com/mirage/ocaml-ipaddr.git
* Bug tracker: https://github.com/mirage/ocaml-ipaddr/issues

---
:camel: Pull-request generated by opam-publish v2.0.0