### PR TITLE
2 packages from mirage/mirage-kv at 2.0.0

### DIFF
--- a/packages/mirage-kv-lwt-riscv/mirage-kv-lwt-riscv.2.0.0/opam
+++ b/packages/mirage-kv-lwt-riscv/mirage-kv-lwt-riscv.2.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-kv-lwt" "-j" jobs]
+]
+
+depends: [
+  "ocaml"     {>= "4.05.0"}
+  "dune"
+  "ocaml-riscv"
+  "mirage-kv-riscv" {>= "2.0.0"}
+  "lwt-riscv"
+  "cstruct-riscv"
+]
+
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv-lwt provides the `Mirage_kv_lwt.RO` and `Mirage_kv_lwt.RW` signatures,
+which are the corresponding `Mirage_kv` signatures with `io` constrained to
+`Lwt.t` and `value` to `string`.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v2.0.0/mirage-kv-v2.0.0.tbz"
+  checksum: "md5=ae3aed9d16c93fc67a429ea1b5727dca"
+}

--- a/packages/mirage-kv-riscv/mirage-kv-riscv.2.0.0/opam
+++ b/packages/mirage-kv-riscv/mirage-kv-riscv.2.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-kv" "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"
+  "ocaml-riscv"
+  "mirage-device-riscv" {>= "1.0.0"}
+  "fmt-riscv" {>= "0.8.4"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v2.0.0/mirage-kv-v2.0.0.tbz"
+  checksum: "md5=ae3aed9d16c93fc67a429ea1b5727dca"
+}


### PR DESCRIPTION
MirageOS signatures for key/value devices

This pull-request concerns:
-`mirage-kv-lwt-riscv.2.0.0`
-`mirage-kv-riscv.2.0.0`



---
* Homepage: https://github.com/mirage/mirage-kv
* Source repo: git+https://github.com/mirage/mirage-kv.git
* Bug tracker: https://github.com/mirage/mirage-kv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0