### PR TITLE
2 packages from mirage/mirage-protocols at 3.0.0

### DIFF
--- a/packages/mirage-protocols-lwt-riscv/mirage-protocols-lwt-riscv.3.0.0/opam
+++ b/packages/mirage-protocols-lwt-riscv/mirage-protocols-lwt-riscv.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-x" "riscv" "-p" "mirage-protocols-lwt" "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-protocols-riscv" {>= "2.0.0"}
+  "ipaddr-riscv" {>= "3.0.0"}
+  "macaddr-riscv"
+  "lwt-riscv"
+  "cstruct-riscv" {>= "1.9.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols-lwt provides a set of module types specialized to lwt which
+libraries intended to be used as MirageOS network implementations should
+implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.0.0/mirage-protocols-v3.0.0.tbz"
+  checksum: [
+    "sha256=b83352a91bb7a693ef7a2022539e789b869903946bbe374bac2df078d60b93e2"
+    "sha512=041c16ee3749562a3900762ef1c179f3d97efb856ec79346223083399cfb13b0e22d2041fb4208b98a557ae5ddf561d79c14362a8ce32dd08fe006b45e4b1c3e"
+  ]
+}

--- a/packages/mirage-protocols-riscv/mirage-protocols-riscv.3.0.0/opam
+++ b/packages/mirage-protocols-riscv/mirage-protocols-riscv.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-x" "riscv" "-p" "mirage-protocols" "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-device-riscv" {>= "1.0.0"}
+  "mirage-flow-riscv" {>= "1.2.0"}
+  "mirage-net-riscv" {>= "2.0.0"}
+  "fmt-riscv"
+  "duration-riscv"
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v3.0.0/mirage-protocols-v3.0.0.tbz"
+  checksum: [
+    "sha256=b83352a91bb7a693ef7a2022539e789b869903946bbe374bac2df078d60b93e2"
+    "sha512=041c16ee3749562a3900762ef1c179f3d97efb856ec79346223083399cfb13b0e22d2041fb4208b98a557ae5ddf561d79c14362a8ce32dd08fe006b45e4b1c3e"
+  ]
+}


### PR DESCRIPTION
MirageOS signatures for network protocols

This pull-request concerns:
-`mirage-protocols-lwt-riscv.3.0.0`
-`mirage-protocols-riscv.3.0.0`



---
* Homepage: https://github.com/mirage/mirage-protocols
* Source repo: git+https://github.com/mirage/mirage-protocols.git
* Bug tracker: https://github.com/mirage/mirage-protocols/issues

---
:camel: Pull-request generated by opam-publish v2.0.0