### PR TITLE
Package mirage-vnetif-riscv.0.4.2

### DIFF
--- a/packages/mirage-vnetif-riscv/mirage-vnetif-riscv.0.4.2/opam
+++ b/packages/mirage-vnetif-riscv/mirage-vnetif-riscv.0.4.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-vnetif" "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {>= "1.0"}
+  "lwt-riscv"
+  "mirage-time-lwt-riscv" {>= "1.0.0"}
+  "mirage-clock-lwt-riscv" {>= "1.2.0"}
+  "mirage-net-lwt-riscv" {>= "2.0.0"}
+  "cstruct-riscv" {>="2.4.0"}
+  "ipaddr-riscv" {>= "3.0.0"}
+  "macaddr-riscv"
+  "mirage-profile-riscv"
+  "duration-riscv"
+  "logs-riscv"
+]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.4.2/mirage-vnetif-v0.4.2.tbz"
+  checksum: "md5=196f5e1cadb53a16d29d3b9c89c65bc4"
+}


### PR DESCRIPTION
### `mirage-vnetif-riscv.0.4.2`
Virtual network interface and software switch for Mirage
Provides the module `Vnetif` which can be used as a replacement for the regular
`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
connected to a software switch that allows the stacks to communicate as if they
were connected to the same LAN.



---
* Homepage: https://github.com/mirage/mirage-vnetif
* Source repo: git+https://github.com/mirage/mirage-vnetif.git
* Bug tracker: https://github.com/mirage/mirage-vnetif/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0