### PR TITLE
2 packages from mirage/mirage-net at 2.0.0

### DIFF
--- a/packages/mirage-net-lwt-riscv/mirage-net-lwt-riscv.2.0.0/opam
+++ b/packages/mirage-net-lwt-riscv/mirage-net-lwt-riscv.2.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-net-lwt" "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-net-riscv" {>= "2.0.0"}
+  "lwt-riscv"
+  "macaddr-riscv"
+  "cstruct-riscv"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}

--- a/packages/mirage-net-riscv/mirage-net-riscv.2.0.0/opam
+++ b/packages/mirage-net-riscv/mirage-net-riscv.2.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-net" "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-device-riscv" {>= "1.0.0"}
+  "fmt-riscv"
+]
+synopsis: "Network signatures for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v2.0.0/mirage-net-v2.0.0.tbz"
+  checksum: "md5=8eab9b0aa56d8d98e578f90de5dc41c2"
+}


### PR DESCRIPTION
Network signatures for MirageOS

This pull-request concerns:
-`mirage-net-lwt-riscv.2.0.0`
-`mirage-net-riscv.2.0.0`



---
* Homepage: https://github.com/mirage/mirage-net
* Source repo: git+https://github.com/mirage/mirage-net.git
* Bug tracker: https://github.com/mirage/mirage-net/issues

---
:camel: Pull-request generated by opam-publish v2.0.0