### PR TITLE
Package base64-riscv.3.2.0

### DIFF
--- a/packages/base64-riscv/base64-riscv.3.2.0/opam
+++ b/packages/base64-riscv/base64-riscv.3.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "http://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>="4.03.0"}
+  "base-bytes"
+  "dune" {>= "1.0.1"}
+  "ocaml-riscv"
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"]
+  ["dune" "build" "-x" "riscv" "-p" "base64" "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.2.0/base64-v3.2.0.tbz"
+  checksum: "md5=8ac1d6145277cee57d36611d1c420f05"
+}


### PR DESCRIPTION
### `base64-riscv.3.2.0`
Base64 encoding for OCaml
Base64 is a group of similar binary-to-text encoding schemes that represent
binary data in an ASCII string format by translating it into a radix-64
representation.  It is specified in RFC 4648.



---
* Homepage: https://github.com/mirage/ocaml-base64
* Source repo: git+https://github.com/mirage/ocaml-base64.git
* Bug tracker: https://github.com/mirage/ocaml-base64/issues

---
:camel: Pull-request generated by opam-publish v2.0.0