### PR TITLE
Package uri-riscv.3.0.0

### DIFF
--- a/packages/uri-riscv/uri-riscv.3.0.0/opam
+++ b/packages/uri-riscv/uri-riscv.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re-riscv" {>= "1.9.0"}
+  "stringext-riscv" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "uri" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v3.0.0/uri-v3.0.0.tbz"
+  checksum: [
+    "sha256=8fb334fba6ebbf879e2e82d80d6adee8bdaf6cec3bb3da248110d805477d19fa"
+    "sha512=553c18032a7c96cccdc8e37f497ce34e821b9dd089cfc8685783b7ade1d4dfa422722e4724abcba8b1171b51fa91a2bee297396fc7c349118069b6352e07881e"
+  ]
+}


### PR DESCRIPTION
### `uri-riscv.3.0.0`
An RFC3986 URI/URL parsing library
This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification 
for parsing URI or URLs.



---
* Homepage: https://github.com/mirage/ocaml-uri
* Source repo: git+https://github.com/mirage/ocaml-uri.git
* Bug tracker: https://github.com/mirage/ocaml-uri/issues

---
:camel: Pull-request generated by opam-publish v2.0.0