### PR TITLE
2 packages from mirage/ocaml-dns at 1.1.3

### DIFF
--- a/packages/dns-lwt-riscv/dns-lwt-riscv.1.1.3/opam
+++ b/packages/dns-lwt-riscv/dns-lwt-riscv.1.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS implementation in portable Lwt"
+description: """
+This is an implementation of the DNS protocol and a client
+and server resolver using the portable Lwt concurrency framework.
+You can find a Unix version of this library in the `dns-lwt-unix`
+opam package, and in theory you could compile this one to JavaScript
+as well using js_of_ocaml.
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.2"}
+  "mirage-profile-riscv" {>= "0.8.0"}
+  "lwt-riscv" {>= "3.0.0"}
+  "dns-riscv" {=version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "dns-lwt" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}

--- a/packages/dns-riscv/dns-riscv.1.1.3/opam
+++ b/packages/dns-riscv/dns-riscv.1.1.3/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+license: "ISC"
+synopsis: "DNS client and server implementation in pure OCaml"
+description: """
+This is a pure OCaml implementation of the DNS protocol.  It is intended to be
+a reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.
+
+There are several concrete implementations using this package that you probably
+want to use for practical purposes:
+
+- dns-lwt for the Lwt concurrency library
+- dns-lwt-unix using the Lwt_unix bindings
+- dns-async using the Jane Street Async library
+- mirage-dns for the MirageOS unikernel framework
+"""
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.2"}
+  "cstruct-riscv" {>= "3.0.2"}
+  "ppx_cstruct-riscv"
+  "re-riscv" {>="1.7.2"}
+  "ipaddr-riscv" {>= "4.0.0"}
+  "uri-riscv" {>= "1.7.0"}
+  "domain-name-riscv" {>="0.3.0"}
+  "base64-riscv" {>= "3.0.0"}
+  "hashcons-riscv"
+  "result-riscv"
+  "mmap" {with-test}
+  "bigarray-compat" {with-test}
+  "pcap-format" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "dns" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dns-lwt-riscv.1.1.3`: DNS implementation in portable Lwt
-`dns-riscv.1.1.3`: DNS client and server implementation in pure OCaml



---
* Homepage: https://github.com/mirage/ocaml-dns
* Source repo: git+https://github.com/mirage/ocaml-dns.git
* Bug tracker: https://github.com/mirage/ocaml-dns/issues

---
:camel: Pull-request generated by opam-publish v2.0.0