### PR TITLE
2 packages from mirage/ocaml-conduit at 2.0.1

### DIFF
--- a/packages/conduit-lwt-riscv/conduit-lwt-riscv.2.0.1/opam
+++ b/packages/conduit-lwt-riscv/conduit-lwt-riscv.2.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv-riscv" {>="v0.9.0"}
+  "sexplib-riscv"
+  "conduit-riscv" {=version}
+  "lwt-riscv" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "conduit-lwt" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}

--- a/packages/conduit-riscv/conduit-riscv.2.0.1/opam
+++ b/packages/conduit-riscv/conduit-riscv.2.0.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv-riscv"
+  "sexplib-riscv"
+  "astring-riscv"
+  "uri-riscv"
+  "logs-riscv" 
+  "ipaddr-riscv"
+  "ipaddr-sexp-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "conduit" "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for 
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v2.0.1/conduit-v2.0.1.tbz"
+  checksum: [
+    "sha256=faf9c1a74bb9f7e0c97637a96968c5198a9344b1dfccbbc2d124d74ac3bedfbb"
+    "sha512=af30cb72ca65e619eb3f38ab3633c1f0ab28dbd7eedd10bcb80f449db9c9b7c433b8553adcb05ac1590ece1797e55bbe5e915255b1ad2fa2dff461a2bfc488aa"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`conduit-lwt-riscv.2.0.1`: A portable network connection establishment library using Lwt
-`conduit-riscv.2.0.1`: A network connection establishment library



---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: git+https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---
:camel: Pull-request generated by opam-publish v2.0.0