### PR TITLE
2 packages from mirage/ocaml-conduit at 2.0.1

### DIFF
--- a/packages/conduit-lwt-riscv/conduit-lwt-riscv.2.0.1/opam
+++ b/packages/conduit-lwt-riscv/conduit-lwt-riscv.2.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "ppx_sexp_conv-riscv" {>="v0.9.0"}
+  "ppx_sexp_conv-riscv" 
   "sexplib-riscv"
   "conduit-riscv" {=version}
   "lwt-riscv" {>= "3.0.0"}


### PR DESCRIPTION
This pull-request concerns:
-`conduit-lwt-riscv.2.0.1`: A portable network connection establishment library using Lwt
-`conduit-riscv.2.0.1`: A network connection establishment library



---
* Homepage: https://github.com/mirage/ocaml-conduit
* Source repo: git+https://github.com/mirage/ocaml-conduit.git
* Bug tracker: https://github.com/mirage/ocaml-conduit/issues

---
:camel: Pull-request generated by opam-publish v2.0.0