### PR TITLE
Package ipaddr-sexp-riscv.4.0.0

### DIFF
--- a/packages/ipaddr-sexp-riscv/ipaddr-sexp-riscv.4.0.0/opam
+++ b/packages/ipaddr-sexp-riscv/ipaddr-sexp-riscv.4.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ipaddr-riscv"
   "ipaddr-cstruct" {with-test}
   "ounit" {with-test}
-  "ppx_sexp_conv-riscv" {>= "v0.9.0"}
+  "ppx_sexp_conv-riscv" 
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
### `ipaddr-sexp-riscv.4.0.0`
A library for manipulation of IP address representations usnig sexp
Sexp convertions for ipaddr



---
* Homepage: https://github.com/mirage/ocaml-ipaddr
* Source repo: git+https://github.com/mirage/ocaml-ipaddr.git
* Bug tracker: https://github.com/mirage/ocaml-ipaddr/issues

---
:camel: Pull-request generated by opam-publish v2.0.0