### PR TITLE
Package mirage-dns-riscv.3.1.3

### DIFF
--- a/packages/mirage-dns-riscv/mirage-dns-riscv.3.1.3/opam
+++ b/packages/mirage-dns-riscv/mirage-dns-riscv.3.1.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+synopsis: "DNS implementation for the MirageOS unikernel framework"
+description: """
+This is an implementation of a DNS server and client resolver
+for the [MirageOS unikernel framework](https://mirage.io).
+"""
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.2"}
+  "dns-lwt" {>="1.1.3" & < "2.0.0"}
+  "duration"
+  "mirage-stack-lwt" {>= "1.3.0"}
+  "mirage-kv-lwt" {>= "2.0.0"}
+  "mirage-time-lwt"
+  "mirage-profile" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v1.1.3/dns-v1.1.3.tbz"
+  checksum: [
+    "sha256=17a3b507d7c1848f14ba213397bcc5df3967bbb9792ec6c650ea5dd9feb5456a"
+    "sha512=cd13ea4c92c018dc884fcce7eb62d2f3f1ef76c3a51c11bb3fe722d72b90e4070f1d0f939cd9faa93c710a4d2dee9761d89557f8086c9fb4ca75c6f1a467fbf3"
+  ]
+}


### PR DESCRIPTION
### `mirage-dns-riscv.3.1.3`
DNS implementation for the MirageOS unikernel framework
This is an implementation of a DNS server and client resolver
for the [MirageOS unikernel framework](https://mirage.io).



---
* Homepage: https://github.com/mirage/ocaml-dns
* Source repo: git+https://github.com/mirage/ocaml-dns.git
* Bug tracker: https://github.com/mirage/ocaml-dns/issues

---
:camel: Pull-request generated by opam-publish v2.0.0