### PR TITLE
Package arp-riscv.2.1.0

### DIFF
--- a/packages/arp-riscv/arp-riscv.2.1.0/opam
+++ b/packages/arp-riscv/arp-riscv.2.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct-riscv" {>= "2.2.0"}
+  "ipaddr-riscv" {>= "4.0.0"}
+  "macaddr-riscv" {>= "4.0.0"}
+  "logs-riscv"
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "arp-mirage" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "arp" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Address Resolution Protocol purely in OCaml"
+description: """
+ARP is an implementation of the address resolution protocol (RFC826) purely in
+OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.
+"""
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.1.0/arp-v2.1.0.tbz"
+  checksum: [
+    "sha256=ac2c004d500237ea2416ddf2a70b804df1aeeec894e58272aff7890410c8495d"
+    "sha512=7add4366202d671bf9e3013eedf699450611229bbd938d1dced449308c25a3afd5f6f53ec3a5969c756c95400cceb95cadb145ac04d2983db4a23e07801c86d5"
+  ]
+}


### PR DESCRIPTION
### `arp-riscv.2.1.0`
Address Resolution Protocol purely in OCaml
ARP is an implementation of the address resolution protocol (RFC826) purely in
OCaml.  It handles IPv4 protocol addresses and Ethernet hardware addresses only.



---
* Homepage: https://github.com/mirage/arp
* Source repo: git+https://github.com/mirage/arp.git
* Bug tracker: https://github.com/mirage/arp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0