### PR TITLE
Package arp-mirage-riscv.2.1.0

### DIFF
--- a/packages/arp-mirage-riscv/arp-mirage-riscv.2.1.0/opam
+++ b/packages/arp-mirage-riscv/arp-mirage-riscv.2.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/arp"
+doc: "https://mirage.github.io/arp/"
+dev-repo: "git+https://github.com/mirage/arp.git"
+bug-reports: "https://github.com/mirage/arp/issues"
+license: "ISC"
+synopsis: "Address Resolution Protocol for MirageOS"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "mirage-time-lwt-riscv"
+  "mirage-protocols-lwt-riscv" {>= "2.0.0"}
+  "lwt-riscv"
+  "duration-riscv"
+  "arp-riscv" {= version}
+  "mirage-profile-riscv" {>= "0.5"}
+  "logs-riscv"
+  "cstruct-riscv" {>= "2.2.0"}
+  "ethernet" {with-test & >= "2.0.0"}
+  "fmt" {with-test}
+  "mirage-vnetif" {with-test}
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random" {with-test}
+  "mirage-random-test" {with-test}
+  "mirage-unix" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "arp-mirage" "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/arp/releases/download/v2.1.0/arp-v2.1.0.tbz"
+  checksum: [
+    "sha256=ac2c004d500237ea2416ddf2a70b804df1aeeec894e58272aff7890410c8495d"
+    "sha512=7add4366202d671bf9e3013eedf699450611229bbd938d1dced449308c25a3afd5f6f53ec3a5969c756c95400cceb95cadb145ac04d2983db4a23e07801c86d5"
+  ]
+}


### PR DESCRIPTION
### `arp-mirage-riscv.2.1.0`
Address Resolution Protocol for MirageOS



---
* Homepage: https://github.com/mirage/arp
* Source repo: git+https://github.com/mirage/arp.git
* Bug tracker: https://github.com/mirage/arp/issues

---
:camel: Pull-request generated by opam-publish v2.0.0