### PR TITLE
Package ethernet-riscv.2.1.0

### DIFF
--- a/packages/ethernet-riscv/ethernet-riscv.2.1.0/opam
+++ b/packages/ethernet-riscv/ethernet-riscv.2.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "ethernet" "-j" jobs]
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.04.0"}
+  "rresult-riscv" {>= "0.5.0"}
+  "cstruct-riscv" {>= "3.0.2"}
+  "ppx_cstruct-riscv"
+  "mirage-net-lwt-riscv" {>= "2.0.0"}
+  "mirage-protocols-lwt-riscv" {>= "2.0.0"}
+  "macaddr-riscv" {>= "4.0.0"}
+  "mirage-profile-riscv" {>= "0.5"}
+  "fmt-riscv"
+  "lwt-riscv" {>= "3.0.0"}
+  "logs-riscv" {>= "0.6.0"}
+]
+conflicts: [
+  "tcpip" {< "3.7.0"}
+]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v2.1.0/ethernet-v2.1.0.tbz"
+  checksum: [
+    "sha256=692c6bbc994abea0e36c519666b8bb12ad42009dc36524c63ded6ce0569a5b70"
+    "sha512=2f619dd47623e36b6e94829e757535997992b974358d8dd783578de7b49a3f932194dd13dbf6d756095b525215c9afd5db4380b49e56dfeec8dfd9d0ecde6bb9"
+  ]
+}


### PR DESCRIPTION
### `ethernet-riscv.2.1.0`
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS
`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
(specified by IEEE 802.3) layer implementation for the
[Mirage operating system](https://mirage.io).



---
* Homepage: https://github.com/mirage/ethernet
* Source repo: git+https://github.com/mirage/ethernet.git
* Bug tracker: https://github.com/mirage/ethernet/issues

---
:camel: Pull-request generated by opam-publish v2.0.0