### PR TITLE
Package randomconv-riscv.0.1.2

### DIFF
--- a/packages/randomconv-riscv/randomconv-riscv.0.1.2/opam
+++ b/packages/randomconv-riscv/randomconv-riscv.0.1.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/randomconv"
+doc: "https://hannesm.github.io/randomconv/doc"
+bug-reports: "https://github.com/hannesm/randomconv/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "cstruct-riscv" {>= "1.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "randomconv" "-j" jobs]
+]
+dev-repo: "git+https://github.com/hannesm/randomconv.git"
+synopsis: "Convert from random byte vectors (Cstruct.t) to random native numbers"
+description: """
+Given a function which produces random byte vectors, convert it to
+a number of your choice (int8/int16/int32/int64/int/float).
+"""
+url {
+  src:
+    "https://github.com/hannesm/randomconv/releases/download/0.1.2/randomconv-0.1.2.tbz"
+  checksum: "md5=f5be15b892d65b94d6cbbaec218f77f8"
+}


### PR DESCRIPTION
### `randomconv-riscv.0.1.2`
Convert from random byte vectors (Cstruct.t) to random native numbers
Given a function which produces random byte vectors, convert it to
a number of your choice (int8/int16/int32/int64/int/float).



---
* Homepage: https://github.com/hannesm/randomconv
* Source repo: git+https://github.com/hannesm/randomconv.git
* Bug tracker: https://github.com/hannesm/randomconv/issues

---
:camel: Pull-request generated by opam-publish v2.0.0