### PR TITLE
Package mirage-os-shim-riscv.3.1.0

### DIFF
--- a/packages/mirage-os-shim-riscv/mirage-os-shim-riscv.3.1.0/opam
+++ b/packages/mirage-os-shim-riscv/mirage-os-shim-riscv.3.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel"
+authors: ["David Kaloper Meršinjak <david@numm.org>"]
+homepage: "https://github.com/mirage/mirage-os-shim"
+doc: "https://mirage.github.io/mirage-os-shim/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/mirage-os-shim.git"
+bug-reports: "https://github.com/mirage/mirage-os-shim/issues"
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "--toolchain" "riscv"
+          "--with-mirage-riscv" "true"
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocaml-riscv"
+  "lwt-riscv"
+  "mirage-riscv"
+]
+
+conflicts: [
+  "mirage-unix" {< "3.1.0"}
+  "mirage-xen" {< "3.1.0"}
+  "mirage-solo5" {< "0.5.0"}
+]
+synopsis: "Portable shim for MirageOS OS API"
+description: """
+mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
+modules by various Mirage backends. It shims out this interface under the same
+`cmi`, and installs several implementations, that pass through to their
+respective backends.
+
+Clients need to be compiled against the common `mirage_OS.cmi`, and use the
+module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
+have to define one of the `ocamlfind` predicates corresponding to the actual
+`OS` implementations: `mirage_unix`, `mirage_xen`, or `mirage_solo5`.
+
+When using `ocamlbuild`, this is
+`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.
+
+**WARNING** Direct access to the `OS` interface is largely deprecated. The
+interface is pretty volatile. It is highly likely that you, in fact, do not need
+this package at all.
+"""
+
+url {
+archive: "https://github.com/mirage/mirage-os-shim/releases/download/v3.1.0/mirage-os-shim-3.1.0.tbz"
+checksum: "3858cf40ab6cf906d47f3e78d8cd40f9"
+}


### PR DESCRIPTION
### `mirage-os-shim-riscv.3.1.0`
Portable shim for MirageOS OS API
mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
modules by various Mirage backends. It shims out this interface under the same
`cmi`, and installs several implementations, that pass through to their
respective backends.

Clients need to be compiled against the common `mirage_OS.cmi`, and use the
module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
have to define one of the `ocamlfind` predicates corresponding to the actual
`OS` implementations: `mirage_unix`, `mirage_xen`, or `mirage_solo5`.

When using `ocamlbuild`, this is
`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.

**WARNING** Direct access to the `OS` interface is largely deprecated. The
interface is pretty volatile. It is highly likely that you, in fact, do not need
this package at all.



---
* Homepage: https://github.com/mirage/mirage-os-shim
* Source repo: git+https://github.com/mirage/mirage-os-shim.git
* Bug tracker: https://github.com/mirage/mirage-os-shim/issues

---
:camel: Pull-request generated by opam-publish v2.0.0