### PR TITLE
Package mirage-entropy-riscv.0.4.1

### DIFF
--- a/packages/mirage-entropy-riscv/mirage-entropy-riscv.0.4.1/opam
+++ b/packages/mirage-entropy-riscv/mirage-entropy-riscv.0.4.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-entropy"
+dev-repo: "git+https://github.com/mirage/mirage-entropy.git"
+bug-reports:  "https://github.com/mirage/mirage-entropy/issues"
+doc:          "https://mirage.github.io/mirage-entropy/doc"
+maintainer:   "david@numm.org"
+license:      "BSD-2-Clause"
+
+build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "--toolchain" "riscv" ]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build}
+  "ocb-stubblr" {build}
+  "cstruct-riscv"
+  "mirage-os-shim-riscv"
+  "lwt-riscv"
+  "mirage-riscv"
+]
+tags: [ "org:mirage"]
+synopsis: "Entropy source for MirageOS unikernels"
+description: """
+mirage-entropy implements various entropy sources for MirageOS unikernels:
+- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
+- rdseed and rdrand (x86/x86-64 only)
+
+## Documentation
+
+[![Build Status](https://travis-ci.org/mirage/mirage-entropy.svg?branch=master)](https://travis-ci.org/mirage/mirage-entropy)
+
+* Documentation: <https://mirage.github.io/mirage-entropy/doc>
+* WWW: <https://mirage.io>
+* E-mail: <mirageos-devel@lists.xenproject.org>
+* Issues: <https://github.com/mirage/mirage-entropy/issues>
+* IRC: `#mirage` on Freenode"""
+authors: ["Hannes Mehnert" "David Kaloper" "Anil Madhavapeddy" "Dave Scott"]
+url {
+  src:
+    "https://github.com/mirage/mirage-entropy/releases/download/0.4.1/mirage-entropy-0.4.1.tbz"
+  checksum: "md5=42bfa3f40a77131eb7cbf750c7227a08"
+}


### PR DESCRIPTION
### `mirage-entropy-riscv.0.4.1`
Entropy source for MirageOS unikernels
mirage-entropy implements various entropy sources for MirageOS unikernels:
- timer based ones (see [whirlwind RNG paper](https://www.ieee-security.org/TC/SP2014/papers/Not-So-RandomNumbersinVirtualizedLinuxandtheWhirlwindRNG.pdf))
- rdseed and rdrand (x86/x86-64 only)

## Documentation

[![Build Status](https://travis-ci.org/mirage/mirage-entropy.svg?branch=master)](https://travis-ci.org/mirage/mirage-entropy)

* Documentation: <https://mirage.github.io/mirage-entropy/doc>
* WWW: <https://mirage.io>
* E-mail: <mirageos-devel@lists.xenproject.org>
* Issues: <https://github.com/mirage/mirage-entropy/issues>
* IRC: `#mirage` on Freenode



---
* Homepage: https://github.com/mirage/mirage-entropy
* Source repo: git+https://github.com/mirage/mirage-entropy.git
* Bug tracker: https://github.com/mirage/mirage-entropy/issues

---
:camel: Pull-request generated by opam-publish v2.0.0