### PR TITLE
Package mirage-os-shim-riscv.3.1.0

### DIFF
--- a/packages/mirage-os-shim-riscv/mirage-os-shim-riscv.3.1.0/opam
+++ b/packages/mirage-os-shim-riscv/mirage-os-shim-riscv.3.1.0/opam
@@ -7,9 +7,9 @@ license: "ISC"
 dev-repo: "git+https://github.com/mirage/mirage-os-shim.git"
 bug-reports: "https://github.com/mirage/mirage-os-shim/issues"
 build: [
-  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "--toolchain" "riscv"
-          "--with-mirage-riscv" "true"
+  "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" "--toolchain" "riscv" 
 ]
+
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
### `mirage-os-shim-riscv.3.1.0`
Portable shim for MirageOS OS API
mirage-os-shim is the intersection of the Mirage OS APIs exported under the `OS`
modules by various Mirage backends. It shims out this interface under the same
`cmi`, and installs several implementations, that pass through to their
respective backends.

Clients need to be compiled against the common `mirage_OS.cmi`, and use the
module `Mirage_OS`. Final applications need to be linked using `ocamlfind`, and
have to define one of the `ocamlfind` predicates corresponding to the actual
`OS` implementations: `mirage_unix`, `mirage_xen`, or `mirage_solo5`.

When using `ocamlbuild`, this is
`ocamlfind -use-ocamlfind -tag 'predicate(unix)'` or similar.

**WARNING** Direct access to the `OS` interface is largely deprecated. The
interface is pretty volatile. It is highly likely that you, in fact, do not need
this package at all.



---
* Homepage: https://github.com/mirage/mirage-os-shim
* Source repo: git+https://github.com/mirage/mirage-os-shim.git
* Bug tracker: https://github.com/mirage/mirage-os-shim/issues

---
:camel: Pull-request generated by opam-publish v2.0.0