### PR TITLE
Package lru-riscv.0.3.0

### DIFF
--- a/packages/lru-riscv/lru-riscv.0.3.0/opam
+++ b/packages/lru-riscv/lru-riscv.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+authors: ["David Kaloper Meršinjak <dk505@cam.ac.uk>"]
+homepage: "https://github.com/pqwy/lru"
+doc: "https://pqwy.github.io/lru/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/pqwy/lru.git"
+bug-reports: "https://github.com/pqwy/lru/issues"
+synopsis: "Scalable LRU caches"
+build: [ [ "dune" "subst" ] {pinned}
+         [ "dune" "build" "-x" "riscv" "-p" "lru" "-j" jobs ]
+         [ "dune" "runtest" "-p" name ] {with-test} ]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>= "1.7"}
+  "psq-riscv"   {>="0.2.0"}
+  "qcheck-core"     {with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest"        {with-test}
+]
+description: """
+Lru provides weight-bounded finite maps that can remove the least-recently-used
+(LRU) bindings in order to maintain a weight constraint.
+"""
+url {
+  src: "https://github.com/pqwy/lru/releases/download/v0.3.0/lru-v0.3.0.tbz"
+  checksum: "md5=ecaa8c9f5f708879140961ce35bcdba4"
+}


### PR DESCRIPTION
### `lru-riscv.0.3.0`
Scalable LRU caches
Lru provides weight-bounded finite maps that can remove the least-recently-used
(LRU) bindings in order to maintain a weight constraint.



---
* Homepage: https://github.com/pqwy/lru
* Source repo: git+https://github.com/pqwy/lru.git
* Bug tracker: https://github.com/pqwy/lru/issues

---
:camel: Pull-request generated by opam-publish v2.0.0