### PR TITLE
Package tcpip-riscv.3.7.8

### DIFF
--- a/packages/tcpip-riscv/tcpip-riscv.3.7.8/opam
+++ b/packages/tcpip-riscv/tcpip-riscv.3.7.8/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/riscv-sysroot/lib/pkgconfig" "dune" "build" "-x" "riscv" "-p" "tcpip" "-j" jobs]
+  ["env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/riscv-sysroot/lib/pkgconfig" "dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+
+depends: [
+  "dune" {>= "1.0"}
+  "dune-configurator"
+  "ocaml" {>= "4.03.0"}
+  "rresult-riscv" {>= "0.5.0"}
+  "cstruct-riscv" {>= "3.2.0"}
+  "cstruct-lwt-riscv"
+  "mirage-net-lwt-riscv" {>= "2.0.0"}
+  "mirage-clock-riscv" {>= "1.2.0"}
+  "mirage-random-riscv" {>= "1.0.0"}
+  "mirage-clock-lwt-riscv" {>= "1.2.0"}
+  "mirage-stack-lwt-riscv" {>= "1.3.0"}
+  "mirage-protocols-riscv" {>= "3.0.0"}
+  "mirage-protocols-lwt-riscv" {>= "3.0.0"}
+  "mirage-time-lwt-riscv" {>= "1.0.0"}
+  "ipaddr-riscv" {>= "4.0.0"}
+  "macaddr-riscv" {>="4.0.0"}
+  "macaddr-cstruct-riscv"
+  "mirage-profile-riscv" {>= "0.5"}
+  "fmt-riscv"
+  "lwt-riscv" {>= "3.0.0"}
+  "lwt-dllist-riscv"
+  "logs-riscv" {>= "0.6.0"}
+  "duration-riscv"
+  "randomconv-riscv"
+  "ethernet-riscv" {>= "2.0.0"}
+  "mirage-flow" {with-test & >= "1.2.0"}
+  "mirage-vnetif" {with-test & >= "0.4.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "mirage-random-test" {with-test}
+  "arp-mirage" {with-test & >= "2.0.0"}
+  "lru-riscv" {>= "0.3.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v3.7.8/tcpip-v3.7.8.tbz"
+  checksum: [
+    "sha256=96cb7d795d1de42c3bc6f62b85125206abb95cc12ad4f2bd276c46b79833d91a"
+    "sha512=641aba24672398776aabadbb3823a58f828b465fc1c4e8856a86aa37f1c5916a1c40076512b6b0d5572e002932950b93f396439390f16c3329ceb320027e1615"
+  ]
+}


### PR DESCRIPTION
### `tcpip-riscv.3.7.8`
OCaml TCP/IP networking stack, used in MirageOS
`mirage-tcpip` provides a networking stack for the [Mirage operating
system](https://mirage.io). It provides implementations for the following module types
(which correspond with the similarly-named protocols):

* IP (via the IPv4 and IPv6 modules)
* ICMP
* UDP
* TCP



---
* Homepage: https://github.com/mirage/mirage-tcpip
* Source repo: git+https://github.com/mirage/mirage-tcpip.git
* Bug tracker: https://github.com/mirage/mirage-tcpip/issues

---
:camel: Pull-request generated by opam-publish v2.0.0