### PR TITLE
Package mirage-riscv.0.5.0

### DIFF
--- a/packages/mirage-riscv/mirage-riscv.0.5.0/opam
+++ b/packages/mirage-riscv/mirage-riscv.0.5.0/opam
@@ -50,7 +50,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage-riscv/archive/v0.5.0.tar.gz"
   checksum: [
-    "md5=30f7bc3482257ad4865165296b391a55"
-    "sha512=a6fe193164ce38ca431d3bfdbd70128c247784686394d4609a00d5f9aa4984b3bdcf89517db320427a1bc19b407bca23f4cc3f0e46b740df570c974b76db275a"
+    "md5=381fafed85601aa89ec8957912ab9529"
+    "sha512=94bc85944e2584d2459b650300ce259acf5e8627b0e650b80906b9bf54aad9de5194f62d9018dd3b4b5d12da9439bb43375bc8fca4a6e8d0ee19be81c4510154"
   ]
 }


### PR DESCRIPTION
### `mirage-riscv.0.5.0`
RISC-V core platform libraries for MirageOS
This package provides the MirageOS `OS` library for
RISC-V targets, which handles the main loop
and timers. It also provides the low level C startup code and C stubs required
by the OCaml code.

The OCaml runtime and C runtime required to support it are provided separately
by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.



---
* Homepage: https://github.com/mirage-shakti-iitm/mirage-riscv
* Source repo: git+https://github.com/mirage-shakti-iitm/mirage-riscv.git
* Bug tracker: https://github.com/mirage-shakti-iitm/mirage-riscv/issues/

---
:camel: Pull-request generated by opam-publish v2.0.0