### PR TITLE
Package mirage-random-test-riscv.0.0.1

### DIFF
--- a/packages/mirage-random-test-riscv/mirage-random-test-riscv.0.0.1/opam
+++ b/packages/mirage-random-test-riscv/mirage-random-test-riscv.0.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:    "hannes@mehnert.org"
+homepage:      "https://github.com/mirage/mirage-random-test"
+bug-reports:   "https://github.com/mirage/mirage-random-test/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random-test.git"
+doc:           "https://mirage.github.io/mirage-random-test/"
+authors:       ["Hannes Mehnert"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-x" "riscv" "-p" "mirage-random-test" "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "cstruct-riscv" {>= "1.9.0"}
+  "ocaml" {>= "4.04.2"}
+  "ocaml-riscv"
+  "mirage-random-riscv"
+]
+
+synopsis: "Stub random device implementation for testing"
+description: """
+mirage-random-test implements `Mirage_random.C` as stub for testing.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random-test/releases/download/0.0.1/mirage-random-test-0.0.1.tbz"
+  checksum: "md5=54811f678be6d1e3bb657791cca6deff"
+}


### PR DESCRIPTION
### `mirage-random-test-riscv.0.0.1`
Stub random device implementation for testing
mirage-random-test implements `Mirage_random.C` as stub for testing.



---
* Homepage: https://github.com/mirage/mirage-random-test
* Source repo: git+https://github.com/mirage/mirage-random-test.git
* Bug tracker: https://github.com/mirage/mirage-random-test/issues

---
:camel: Pull-request generated by opam-publish v2.0.0