### PR TITLE
Package hex-riscv.1.4.0

### DIFF
--- a/packages/hex-riscv/hex-riscv.1.4.0/opam
+++ b/packages/hex-riscv/hex-riscv.1.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Trevor Summers Smith"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hex"
+doc: "https://mirage.github.io/ocaml-hex/"
+bug-reports: "https://github.com/mirage/ocaml-hex/issues"
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune" {build & >= "1.0"}
+  "ocaml-riscv"
+  "cstruct-riscv" 
+  "bigarray-compat-riscv"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-x" "riscv" "-p" "hex" "-j" jobs]
+  ["dune" "runtest" "-p" "hex" "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
+synopsis: "Library providing hexadecimal converters"
+description: """
+```ocaml
+#require "hex";;
+# Hex.of_string "Hello world!";;
+- : Hex.t = "48656c6c6f20776f726c6421"
+# Hex.to_string "dead-beef";;
+- : string = "ޭ��"
+# Hex.hexdump (Hex.of_string "Hello world!\n")
+00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
+- : unit = ()
+```
+"""
+
+url {
+  src:
+    "https://github.com/mirage/ocaml-hex/releases/download/v1.4.0/hex-v1.4.0.tbz"
+  checksum: "md5=57103ff33e70f14171c46d88f5452d11"
+}


### PR DESCRIPTION
### `hex-riscv.1.4.0`
Library providing hexadecimal converters
```ocaml
#require "hex";;
# Hex.of_string "Hello world!";;
- : Hex.t = "48656c6c6f20776f726c6421"
# Hex.to_string "dead-beef";;
- : string = "ޭ��"
# Hex.hexdump (Hex.of_string "Hello world!
")
00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
- : unit = ()
```



---
* Homepage: https://github.com/mirage/ocaml-hex
* Source repo: git+https://github.com/mirage/ocaml-hex.git
* Bug tracker: https://github.com/mirage/ocaml-hex/issues

---
:camel: Pull-request generated by opam-publish v2.0.0