### PR TITLE
4 packages from mirage-shakti-iitm/mirage at 3.5.0

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.5.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.5.0/opam
@@ -32,7 +32,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=66d7b5dc2e011531851f7715faf05f5b"
-    "sha512=f969ea58c543df3861d65d94ea81cc775a478e1a25d73e5d0a32aea406df71a466c523ab03579f8f8ed456554d14a87f51e3284bfb9a62e53846d809b6e228cf"
+    "md5=81b6ca19e8af537a66346b5e70978d3d"
+    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
   ]
 }

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
@@ -50,7 +50,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=66d7b5dc2e011531851f7715faf05f5b"
-    "sha512=f969ea58c543df3861d65d94ea81cc775a478e1a25d73e5d0a32aea406df71a466c523ab03579f8f8ed456554d14a87f51e3284bfb9a62e53846d809b6e228cf"
+    "md5=81b6ca19e8af537a66346b5e70978d3d"
+    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
   ]
 }

--- a/packages/mirage-types/mirage-types.3.5.0/opam
+++ b/packages/mirage-types/mirage-types.3.5.0/opam
@@ -41,7 +41,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=66d7b5dc2e011531851f7715faf05f5b"
-    "sha512=f969ea58c543df3861d65d94ea81cc775a478e1a25d73e5d0a32aea406df71a466c523ab03579f8f8ed456554d14a87f51e3284bfb9a62e53846d809b6e228cf"
+    "md5=81b6ca19e8af537a66346b5e70978d3d"
+    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
   ]
 }

--- a/packages/mirage/mirage.3.5.0/opam
+++ b/packages/mirage/mirage.3.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
   "ipaddr"             {>= "3.0.0"}
-  "functoria"          {>= "2.2.3"}
+  "functoria"          {= "3.0.3"}
   "bos"
   "astring"
   "logs"
@@ -43,7 +43,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=66d7b5dc2e011531851f7715faf05f5b"
-    "sha512=f969ea58c543df3861d65d94ea81cc775a478e1a25d73e5d0a32aea406df71a466c523ab03579f8f8ed456554d14a87f51e3284bfb9a62e53846d809b6e228cf"
+    "md5=81b6ca19e8af537a66346b5e70978d3d"
+    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`mirage.3.5.0`: The MirageOS library operating system
-`mirage-runtime.3.5.0`: The base MirageOS runtime library, part of every MirageOS unikernel
-`mirage-types.3.5.0`: Module type definitions for MirageOS applications
-`mirage-types-lwt.3.5.0`: Lwt module type definitions for MirageOS applications



---
* Homepage: https://github.com/mirage/mirage
* Source repo: git+https://github.com/mirage/mirage.git
* Bug tracker: https://github.com/mirage/mirage/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2