### PR TITLE
5 packages from mirage-shakti-iitm/mirage

### DIFF
--- a/packages/mirage-runtime-riscv/mirage-runtime-riscv.3.5.0+riscv/opam
+++ b/packages/mirage-runtime-riscv/mirage-runtime-riscv.3.5.0+riscv/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+maintainer:   "Sai Venkata Krishnan <saiganesha5.svkv@gmail.com>"
 authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
                "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
                "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
@@ -12,17 +12,18 @@ doc:          "https://mirage.github.io/mirage/"
 
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-x" "riscv" "-p" "mirage-runtime" "-j" jobs]
+  ["dune" "runtest" "-p" "mirage-runtime" "-j" jobs] {with-test}
 ]
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.07.0"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
-  "functoria-runtime"  {>= "2.2.4" & < "3.0.3"}
-  "fmt"
-  "logs"
+  "ocaml-riscv"
+  "ipaddr-riscv"
+  "functoria-runtime-riscv"
+  "fmt-riscv"
+  "logs-riscv"
 ]
 synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
 description: """
@@ -32,7 +33,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=6ede5f7c849ccc3e12d67f59c8a6edb4"
-    "sha512=4e0be1249c2c058ef348c40e84fe8b63e20e57c9b2bf1d84c26d65ab076b6bfa4e1fc2b5c36d2710274fe44b02ec9e15104951c0f6cfb75aa19ef9bcc3f6d558"
+    "md5=66d7b5dc2e011531851f7715faf05f5b"
+    "sha512=f969ea58c543df3861d65d94ea81cc775a478e1a25d73e5d0a32aea406df71a466c523ab03579f8f8ed456554d14a87f51e3284bfb9a62e53846d809b6e228cf"
   ]
 }

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.5.0/opam
@@ -19,7 +19,7 @@ depends:   [
   "dune" {build & >= "1.1.0"}
   "lwt"
   "cstruct" {>="3.2.1"}
-  "ipaddr" {>= "3.0.0"}
+  "ipaddr" {>= "3.0.0" & < "5.0.0"}
   "mirage-types" {>= "3.5.0"}
   "mirage-clock-lwt" {>= "2.0.0"}
   "mirage-time-lwt" {>= "1.1.0"}
@@ -50,7 +50,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=81b6ca19e8af537a66346b5e70978d3d"
-    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
+    "md5=6ede5f7c849ccc3e12d67f59c8a6edb4"
+    "sha512=4e0be1249c2c058ef348c40e84fe8b63e20e57c9b2bf1d84c26d65ab076b6bfa4e1fc2b5c36d2710274fe44b02ec9e15104951c0f6cfb75aa19ef9bcc3f6d558"
   ]
 }

--- a/packages/mirage-types/mirage-types.3.5.0/opam
+++ b/packages/mirage-types/mirage-types.3.5.0/opam
@@ -41,7 +41,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=81b6ca19e8af537a66346b5e70978d3d"
-    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
+    "md5=6ede5f7c849ccc3e12d67f59c8a6edb4"
+    "sha512=4e0be1249c2c058ef348c40e84fe8b63e20e57c9b2bf1d84c26d65ab076b6bfa4e1fc2b5c36d2710274fe44b02ec9e15104951c0f6cfb75aa19ef9bcc3f6d558"
   ]
 }

--- a/packages/mirage/mirage.3.5.0/opam
+++ b/packages/mirage/mirage.3.5.0/opam
@@ -19,8 +19,8 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {build & >= "1.1.0"}
-  "ipaddr"             {>= "3.0.0"}
-  "functoria"          {= "3.0.3"}
+  "ipaddr"             {>= "3.0.0" & < "5.0.0"}
+  "functoria"          {>= "2.2.4" & < "3.0.3"}
   "bos"
   "astring"
   "logs"
@@ -43,7 +43,7 @@ url {
   src:
     "https://github.com/mirage-shakti-iitm/mirage/archive/v3.5.0+riscv.tar.gz"
   checksum: [
-    "md5=81b6ca19e8af537a66346b5e70978d3d"
-    "sha512=a0c983583154e04f08a84d5220d0cac557a3fe5267170c2d659d582c9e5d4291ffd78ceaa56229404864658dab5dc8e5a1ef8f44550b0667248cb337b19818d1"
+    "md5=6ede5f7c849ccc3e12d67f59c8a6edb4"
+    "sha512=4e0be1249c2c058ef348c40e84fe8b63e20e57c9b2bf1d84c26d65ab076b6bfa4e1fc2b5c36d2710274fe44b02ec9e15104951c0f6cfb75aa19ef9bcc3f6d558"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`mirage.3.5.0`: The MirageOS library operating system
-`mirage-runtime.3.5.0`: The base MirageOS runtime library, part of every MirageOS unikernel
-`mirage-runtime-riscv.3.5.0+riscv`: The base MirageOS runtime library, part of every MirageOS unikernel
-`mirage-types.3.5.0`: Module type definitions for MirageOS applications
-`mirage-types-lwt.3.5.0`: Lwt module type definitions for MirageOS applications



---
* Homepage: https://github.com/mirage/mirage
* Source repo: git+https://github.com/mirage/mirage.git
* Bug tracker: https://github.com/mirage/mirage/issues/

---
:camel: Pull-request generated by opam-publish v2.0.2